### PR TITLE
Added a module with a low leven hardware abstraction layer

### DIFF
--- a/examples/demo_hal/main.c
+++ b/examples/demo_hal/main.c
@@ -1,0 +1,280 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+/** @file
+ ** @brief Simple sample of use MUJU hal functions
+ **
+ ** @addtogroup sample-hal HAL Sample
+ ** @ingroup samples
+ ** @brief Samples applications with MUJU Framwork
+ ** @{ */
+
+/* === Headers files inclusions =============================================================== */
+
+#include "board.h"
+#include "hal.h"
+
+/* === Macros definitions ====================================================================== */
+
+#if !defined(EDU_CIAA_NXP) && !defined(POSIX)
+#error "This program does not have support for the selected board"
+#endif
+
+/* === Private data type declarations ========================================================== */
+
+/**
+ * @brief Enumeration with color sequence of RGB led
+ */
+typedef enum rgb_color_e {
+    LED_RED_ON = 0, /**< Red led is On */
+    LED_RED_OFF,    /**< Red led is Off */
+    LED_GREEN_ON,   /**< Green led is On */
+    LED_GREEN_OFF,  /**< Green led is Off */
+    LED_BLUE_ON,    /**< Blue led is On */
+    LED_BLUE_OFF,   /**< Blue led is Off */
+} rgb_color_t;
+
+/**
+ * @brief Structure with gpio outputs to drive an RGB led
+ */
+typedef struct led_rgb_s {
+    hal_gpio_bit_t red;   /**< Gpio output used to drive red channel of RGB led */
+    hal_gpio_bit_t green; /**< Gpio output used to drive green channel of RGB led */
+    hal_gpio_bit_t blue;  /**< Gpio output used to drive blue channel of RGB led */
+} const * const led_rgb_t;
+
+/**
+ * @brief Structure with gpio terminals usted by board
+ */
+typedef struct board_s {
+    struct led_rgb_s led_rgb; /**< Structure with gpio output used by RGB led */
+    hal_gpio_bit_t led_1;     /**< Gpio output used to drive led 1 on board */
+    hal_gpio_bit_t led_2;     /**< Gpio output used to drive led 2 on board */
+    hal_gpio_bit_t led_3;     /**< Gpio output used to drive led 3 on board */
+    hal_gpio_bit_t tec_1;     /**< Gpio output used to read status of key 1 on board */
+    hal_gpio_bit_t tec_2;     /**< Gpio output used to read status of key 2 on board */
+    hal_gpio_bit_t tec_3;     /**< Gpio output used to read status of key 3 on board */
+    hal_gpio_bit_t tec_4;     /**< Gpio output used to read status of key 4 on board */
+} const * const board_t;
+
+/* === Private variable declarations =========================================================== */
+
+/* === Private function declarations =========================================================== */
+
+/**
+ * @brief Function to initialize the board and create an descriptor to his resources
+ *
+ * @return  board_t  Pointer to descriptor with board resources
+ */
+static board_t BoardCreate(void);
+
+/**
+ * @brief Function to handle system timer events
+ *
+ * @param  object   Pointer to boolean variable to signal to main loop a new tick
+ */
+static void TickEvent(void * object);
+
+/**
+ * @brief Function to flash RGB led in sequence
+ *
+ * @param  led      Pointer to structure with gpio outputs used by rgb led
+ */
+static void FlashLed(led_rgb_t led);
+
+/**
+ * @brief Function to switch on and off a led with two keys
+ *
+ * @param  key_on   Gpio input used by the key that turns on the led
+ * @param  key_off  Gpio input used by the key that turns off the led
+ * @param  led      Gpio output used by the led drived by the keys
+ */
+static void SwitchLed(hal_gpio_bit_t key_on, hal_gpio_bit_t key_off, hal_gpio_bit_t led);
+
+/**
+ * @brief Function to switch on and off a led with a single key
+ *
+ * @param  key      Gpio input used by the key that turn on and off the led
+ * @param  led      Gpio output used by the led drived by the key
+ */
+static void ToggleLed(hal_gpio_bit_t key, hal_gpio_bit_t led);
+
+/**
+ * @brief Function to turn on a led while a key is pressed
+ *
+ * @param  key      Gpio input used by the key that turn on the led
+ * @param  led      Gpio output used by the led drived by the key
+ */
+static void TestLed(hal_gpio_bit_t key, hal_gpio_bit_t led);
+
+/* === Public variable definitions ============================================================= */
+
+/* === Private variable definitions ============================================================ */
+
+/* === Private function implementation ========================================================= */
+
+static board_t BoardCreate(void) {
+    static struct board_s board;
+
+#ifdef EDU_CIAA_NXP
+    board.led_rgb.red = HAL_GPIO5_0;
+    board.led_rgb.green = HAL_GPIO5_1;
+    board.led_rgb.blue = HAL_GPIO5_2;
+
+    board.led_1 = HAL_GPIO0_14;
+    board.led_2 = HAL_GPIO1_11;
+    board.led_3 = HAL_GPIO1_12;
+
+    board.tec_1 = HAL_GPIO0_4;
+    board.tec_2 = HAL_GPIO0_8;
+    board.tec_3 = HAL_GPIO0_9;
+    board.tec_4 = HAL_GPIO1_9;
+#elif POSIX
+    board.led_rgb.red = HAL_GPIO3_7;
+    board.led_rgb.green = HAL_GPIO3_6;
+    board.led_rgb.blue = HAL_GPIO3_5;
+
+    board.led_1 = HAL_GPIO3_2;
+    board.led_2 = HAL_GPIO3_1;
+    board.led_3 = HAL_GPIO3_0;
+
+    board.tec_1 = HAL_GPIO0_0;
+    board.tec_2 = HAL_GPIO0_1;
+    board.tec_3 = HAL_GPIO0_2;
+    board.tec_4 = HAL_GPIO0_3;
+#endif
+    BoardSetup();
+
+    GpioSetDirection(board.led_rgb.red, true);
+    GpioSetDirection(board.led_rgb.green, true);
+    GpioSetDirection(board.led_rgb.blue, true);
+
+    GpioSetDirection(board.led_1, true);
+    GpioSetDirection(board.led_2, true);
+    GpioSetDirection(board.led_3, true);
+
+    GpioSetDirection(board.tec_1, false);
+    GpioSetDirection(board.tec_2, false);
+    GpioSetDirection(board.tec_3, false);
+    GpioSetDirection(board.tec_4, false);
+
+    return &board;
+}
+
+static void TickEvent(void * object) {
+    *((bool *)object) = true;
+}
+
+static void FlashLed(led_rgb_t led) {
+    static int divisor = 0;
+    static rgb_color_t state = LED_BLUE_OFF;
+
+    divisor++;
+    if (divisor == 500) {
+        divisor = 0;
+        state = (state + 1) % (LED_BLUE_OFF + 1);
+
+        switch (state) {
+        case LED_RED_ON:
+            GpioBitClear(led->green);
+            GpioBitClear(led->blue);
+            GpioBitSet(led->red);
+            break;
+        case LED_GREEN_ON:
+            GpioBitClear(led->red);
+            GpioBitClear(led->blue);
+            GpioBitSet(led->green);
+            break;
+        case LED_BLUE_ON:
+            GpioBitClear(led->red);
+            GpioBitClear(led->green);
+            GpioBitSet(led->blue);
+            break;
+        default:
+            GpioBitClear(led->red);
+            GpioBitClear(led->green);
+            GpioBitClear(led->blue);
+            break;
+        }
+    }
+}
+
+static void SwitchLed(hal_gpio_bit_t key_on, hal_gpio_bit_t key_off, hal_gpio_bit_t led) {
+    if (GpioGetState(key_on) == 0) {
+        GpioSetState(led, true);
+    }
+    if (GpioGetState(key_off) == 0) {
+        GpioSetState(led, false);
+    }
+}
+
+static void ToggleLed(hal_gpio_bit_t key, hal_gpio_bit_t led) {
+    static bool last_state = false;
+    bool current_state;
+
+    current_state = (GpioGetState(key) == 0);
+    if ((current_state) && (!last_state)) {
+        GpioBitToogle(led);
+    }
+    last_state = current_state;
+}
+
+static void TestLed(hal_gpio_bit_t key, hal_gpio_bit_t led) {
+    if (GpioGetState(key) == 0) {
+        GpioSetState(led, true);
+    } else {
+        GpioSetState(led, false);
+    }
+}
+
+/* === Public function implementation ========================================================= */
+
+int main(void) {
+    int divisor = 0;
+    volatile bool new_tick = false;
+    board_t board = BoardCreate();
+    TickStart(TickEvent, (void *)&new_tick, 1000);
+
+    while (true) {
+        while (!new_tick) {
+            __asm("NOP");
+        }
+        new_tick = false;
+
+        FlashLed(&board->led_rgb);
+
+        divisor++;
+        if (divisor == 150) {
+            divisor = 0;
+            SwitchLed(board->tec_1, board->tec_2, board->led_1);
+            ToggleLed(board->tec_3, board->led_2);
+            TestLed(board->tec_4, board->led_3);
+        }
+    }
+}
+
+/* === End of documentation ==================================================================== */
+
+/** @} End of module definition for doxygen */

--- a/makefile
+++ b/makefile
@@ -23,8 +23,8 @@
 # SPDX-License-Identifier: MIT
 ##################################################################################################
 
-MODULES :=
+MODULES := module/hal
 BOARD ?= edu-ciaa-nxp
-PROJECT ?= examples/edu-ciaa-nxp
+PROJECT ?= examples/demo_hal
 
 include module/base/makefile

--- a/module/hal/inc/hal.h
+++ b/module/hal/inc/hal.h
@@ -1,0 +1,65 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef HAL_H
+#define HAL_H
+
+/** @file
+ ** @brief Harware abstraction layer declarations
+ **
+ ** @addtogroup hal HAL
+ ** @brief Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include "hal_gpio.h"
+#include "hal_tick.h"
+#include "soc_gpio.h"
+#include "soc_tick.h"
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/* === Public variable declarations ============================================================ */
+
+/* === Public function declarations ============================================================ */
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* HAL_H */

--- a/module/hal/inc/hal_gpio.h
+++ b/module/hal/inc/hal_gpio.h
@@ -1,0 +1,119 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef HAL_GPIO_H
+#define HAL_GPIO_H
+
+/** @file
+ ** @brief Digital inputs/outputs declarations
+ **
+ ** @addtogroup hal HAL
+ ** @brief Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/**
+ * @brief Pointer to the structure with the gpio terminal descriptor
+ */
+typedef struct hal_gpio_bit_s const * hal_gpio_bit_t;
+
+/* === Public variable declarations ============================================================ */
+
+/* === Public function declarations ============================================================ */
+
+/**
+ * @brief Function to set an gpio pin as input or output
+ *
+ * @param  gpio     Pointer to the structure with the gpio terminal descriptor
+ * @param  output   The gpio terminal should be configured as input or output
+ * @arg @c true     The gpio terminal is configures as an output
+ * @arg @c false    The gpio terminal is configures as an input
+ *
+ */
+void GpioSetDirection(hal_gpio_bit_t gpio, bool output);
+
+/**
+ * @brief Function to the current value of an gpio input or output
+ *
+ * @param  gpio     Pointer to the structure with the gpio terminal descriptor
+ * @return true     The current value of the gpio intput or output is high
+ * @return false    The current value of the gpio intput or output is output
+ */
+bool GpioGetState(hal_gpio_bit_t gpio);
+
+/**
+ * @brief Function to update the current value of an gpio output
+ *
+ * @param  gpio     Pointer to the structure with the gpio terminal descriptor
+ * @param  state    Value to write to the gpio output
+ * @arg @c true     The current value of the gpio output is changed to high
+ * @arg @c false    The current value of the gpio output is changed to low
+ */
+void GpioSetState(hal_gpio_bit_t gpio, bool state);
+
+/**
+ * @brief Function to set the current value to high of an gpio output
+ *
+ * @param  gpio     Pointer to the structure with the gpio terminal descriptor
+ */
+void GpioBitSet(hal_gpio_bit_t gpio);
+
+/**
+ * @brief Function to set the current value to low of an gpio output
+ *
+ * @param  gpio     Pointer to the structure with the gpio terminal descriptor
+ */
+void GpioBitClear(hal_gpio_bit_t gpio);
+
+/**
+ * @brief Function to interchange the current value of an gpio output
+ *
+ * @param  gpio     Pointer to the structure with the gpio terminal descriptor
+ */
+void GpioBitToogle(hal_gpio_bit_t gpio);
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* HAL_GPIO_H */

--- a/module/hal/inc/hal_pin.h
+++ b/module/hal/inc/hal_pin.h
@@ -23,11 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 SPDX-License-Identifier: MIT
 *************************************************************************************************/
 
-#ifndef HAL_H
-#define HAL_H
+#ifndef HAL_PIN_H
+#define HAL_PIN_H
 
 /** @file
- ** @brief Harware abstraction layer declarations
+ ** @brief Chip pins declarations
  **
  ** @addtogroup hal HAL
  ** @brief Hardware abstraction layer
@@ -35,14 +35,8 @@ SPDX-License-Identifier: MIT
 
 /* === Headers files inclusions ================================================================ */
 
-#include "hal_pin.h"
-#include "hal_sci.h"
-#include "hal_gpio.h"
-#include "hal_tick.h"
-#include "soc_pin.h"
-#include "soc_sci.h"
-#include "soc_gpio.h"
-#include "soc_tick.h"
+#include <stdbool.h>
+#include <stdint.h>
 
 /* === Cabecera C++ ============================================================================ */
 
@@ -54,9 +48,44 @@ extern "C" {
 
 /* === Public data type declarations =========================================================== */
 
+/**
+ * @brief Pointer to the structure with the chip pin descriptor
+ */
+typedef struct hal_chip_pin_s const * hal_chip_pin_t;
+
 /* === Public variable declarations ============================================================ */
 
 /* === Public function declarations ============================================================ */
+
+/**
+ * @brief Function to configure a chip pin with function and pull resistors
+ *
+ * @param  pin      Pointer to the structure with the chip pin descriptor
+ * @param  function Numeric function asineg to chip pin
+ * @param  pullup   State to be assigned to the internal pullup resistor
+ * @param  puldown  State to be assigned to the internal pulldown resistor
+ */
+void ChipPinSetFunction(hal_chip_pin_t pin, uint8_t function, bool pullup, bool puldown);
+
+/**
+ * @brief Function to change the internal pullup resistor configuratioxn on chip pin
+ *
+ * @param  pin      Pointer to the structure with the chip pin descriptor
+ * @param  enable   State to be assigned to the internal pullup resistor
+ * @arg @c true     The internal pullup resistor must be enabled
+ * @arg @c false    The internal pullup resistor must be disabled
+ */
+void ChipPinSetPullUp(hal_chip_pin_t pin, bool enable);
+
+/**
+ * @brief Function to change the internal pulldown resistor configuration on chip pin
+ *
+ * @param  pin      Pointer to the structure with the chip pin descriptor
+ * @param  enable   State to be assigned to the internal pullup resistor
+ * @arg @c true     The internal pulldown resistor must be enabled
+ * @arg @c false    The internal pulldown resistor must be disabled
+ */
+void ChipPinSetPullDown(hal_chip_pin_t pin, bool enable);
 
 /* === End of documentation ==================================================================== */
 
@@ -66,4 +95,4 @@ extern "C" {
 
 /** @} End of module definition for doxygen */
 
-#endif /* HAL_H */
+#endif /* HAL_PIN_H */

--- a/module/hal/inc/hal_sci.h
+++ b/module/hal/inc/hal_sci.h
@@ -1,0 +1,167 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef HAL_SCI_H
+#define HAL_SCI_H
+
+/** @file
+ ** @brief Serial ports declarations
+ **
+ ** @addtogroup hal HAL
+ ** @brief Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include "hal_pin.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/**
+ * @brief Enumeration to define parity control used by a serial port
+ */
+typedef enum {
+    HAL_SCI_NO_PARITY,    /**< The parity bit is not calculated or transmitted */
+    HAL_SCI_ODD_PARITY,   /**< The parity bit is calculated as an odd amount of 1's */
+    HAL_SCI_EVEN_PARITY,  /**< The parity bit is calculated as an even amount of 1's */
+    HAL_SCI_MARK_PARITY,  /**< The parity bit is always set to 0 */
+    HAL_SCI_SPACE_PARITY, /**< The parity bit is always set to 1 */
+} sci_parity_t;
+
+/**
+ * @brief Structure to define serial port line parameters
+ */
+typedef struct hal_sci_line_s {
+    uint32_t baud_rate;  /**< Baud rate to be used in serial port */
+    uint8_t data_bits;   /**< Bit per character to be used in serial port */
+    sci_parity_t parity; /**< Parity control to be used in serial port */
+} const * hal_sci_line_t;
+
+/**
+ * @brief Structure to define chip pins used by a serial port
+ */
+typedef struct hal_sci_pins_s {
+    hal_chip_pin_t txd_pin; /**< Chip pin to be used as transmission line */
+    hal_chip_pin_t rxd_pin; /**< Chip pin to be used as reception line */
+} const * hal_sci_pins_t;
+
+/**
+ * @brief Structure with the status flags of a serial port
+ */
+typedef struct sci_status_s {
+    bool data_ready : 1;          /**< The new data is ready in the input fifo on hardware */
+    bool overrun : 1;             /**< Data in input fifo on hardware was overwritten by new data */
+    bool parity_error : 1;        /**< Error in the parity check of the received data */
+    bool framing_error : 1;       /**< Error in the start or stop bits in the received data */
+    bool break_signal : 1;        /**< Signal break detected on reception line */
+    bool fifo_empty : 1;          /**< Output fifo on hardware are ready to accept more data */
+    bool tramition_completed : 1; /**< Tranmission of data in output fifo on hardware completed */
+} * sci_status_t;
+
+/**
+ * @brief Pointer to the structure with the serial port descriptor
+ */
+typedef struct hal_sci_s * hal_sci_t;
+
+/**
+ * @brief Callback function to handle a serial port events
+ *
+ * @param  sci      Pointer to structure with descriptor of serial port that raises the event
+ * @param  status   Pointer to structure with flags that raises the event
+ * @param  object   Pointer to user data declared when handler event has installed
+ */
+typedef void (*hal_sci_event_t)(hal_sci_t sci, sci_status_t status, void * object);
+
+/* === Public variable declarations ============================================================ */
+
+/* === Public function declarations ============================================================ */
+
+/**
+ * @brief Function to configure a serial port before to use it
+ *
+ * @param  sci      Pointer to the structure with the serial port descriptor
+ * @param  line     Pointer to structure with line configuration for serial port
+ * @param  pins     Pointer to structure with chip pins used by serial port
+ * @return true     The settings are valid and the serial port is ready to operate
+ * @return false    The settings are invalid and the serial port was not initialized
+ */
+bool SciSetConfig(hal_sci_t sci, hal_sci_line_t line, hal_sci_pins_t pins);
+
+/**
+ * @brief Function to put data into output fifo on hardware
+ *
+ * @param  sci      Pointer to the structure with the serial port descriptor
+ * @param  data     Pointer to buffer with data to put in output fifo
+ * @param  size     Length of data to put in output fifo
+ * @return uint16_t Amount of data actually put in output fifo
+ */
+uint16_t SciSendData(hal_sci_t sci, void const * const data, uint16_t size);
+
+/**
+ * @brief Function to get data from input fifo on hardware
+ *
+ * @param  sci      Pointer to the structure with the serial port descriptor
+ * @param  data     Pointer to the buffer to store data from input fifo
+ * @param  size     Length of data to get from input fifo
+ * @return uint16_t Amount of data actually get from input fifo
+ */
+uint16_t SciReceiveData(hal_sci_t sci, void * data, uint16_t size);
+
+/**
+ * @brief Function to read serial port status flags
+ *
+ * @param  sci      Pointer to the structure with the serial port descriptor
+ * @param  result   Pointer to structure to write the status flags of a serial port
+ */
+void SciReadStatus(hal_sci_t sci, sci_status_t result);
+
+/**
+ * @brief Function enable serial port interrupts and handle its as events
+ *
+ * @param  sci      Pointer to the structure with the serial port descriptor
+ * @param  handler  Function to call on the serial port events
+ * @param  object   Pointer to user data sended as parameter in handler calls
+ */
+void SciSetEventHandler(hal_sci_t sci, hal_sci_event_t handler, void * object);
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* HAL_SCI_H */

--- a/module/hal/inc/hal_tick.h
+++ b/module/hal/inc/hal_tick.h
@@ -1,0 +1,79 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef HAL_TICK_H
+#define HAL_TICK_H
+
+/** @file
+ ** @brief System timer declarations
+ **
+ ** @addtogroup hal HAL
+ ** @brief Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/**
+ * @brief Callback function to handle a system timer event
+ *
+ * @param  object   Pointer to user data sended as parameter in handler calls
+ */
+typedef void (*hal_tick_event_t)(void * object);
+
+/* === Public variable declarations ============================================================ */
+
+/* === Public function declarations ============================================================ */
+
+/**
+ * @brief Function to start a periodic event of the system timer
+ *
+ * @param  handler  Function to call on the system timer events
+ * @param  object   Pointer to user data sended as parameter in handler calls
+ * @param  period   Period, in microseconds, between each system timer event
+ */
+void TickStart(hal_tick_event_t handler, void * object, uint32_t period);
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* HAL_TICK_H */

--- a/module/hal/makefile
+++ b/module/hal/makefile
@@ -1,0 +1,13 @@
+# Variable with module root foder
+FOLDER := module/hal
+
+# Variable with module name
+$(eval NAME = $(call module_name,$(FOLDER)))
+
+# Variable with the list of folders containing header files for the module
+$(NAME)_INC := $(FOLDER)/inc $(FOLDER)/soc/$(SOC)/inc
+
+# Variable with the list of folders containing source files for the module
+$(NAME)_SRC := $(FOLDER)/src $(FOLDER)/soc/$(SOC)/src
+
+PROJECT_INC += module/hal/inc module/hal/soc/$(SOC)/inc

--- a/module/hal/soc/lpc43xx/inc/soc_gpio.h
+++ b/module/hal/soc/lpc43xx/inc/soc_gpio.h
@@ -1,0 +1,124 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef SOC_GPIO_H
+#define SOC_GPIO_H
+
+/** @file
+ ** @brief Digital inputs/outputs on lpc43xx declarations
+ **
+ ** @addtogroup lpc43xx LPC43xx
+ ** @ingroup hal
+ ** @brief LPC43xx SOC Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include "hal_gpio.h"
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/* === Public variable declarations ============================================================ */
+
+/** @cond !INTERNAL */
+extern const hal_gpio_bit_t HAL_GPIO0_0;  /**< Constant to define Bit 0 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_1;  /**< Constant to define Bit 1 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_2;  /**< Constant to define Bit 2 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_3;  /**< Constant to define Bit 3 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_4;  /**< Constant to define Bit 4 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_5;  /**< Constant to define Bit 5 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_7;  /**< Constant to define Bit 7 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_8;  /**< Constant to define Bit 8 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_9;  /**< Constant to define Bit 9 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_10; /**< Constant to define Bit 10 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_11; /**< Constant to define Bit 11 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_12; /**< Constant to define Bit 12 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_13; /**< Constant to define Bit 13 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_14; /**< Constant to define Bit 14 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_15; /**< Constant to define Bit 15 on GPIO 0 */
+
+extern const hal_gpio_bit_t HAL_GPIO1_8;  /**< Constant to define Bit 8 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_9;  /**< Constant to define Bit 9 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_11; /**< Constant to define Bit 11 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_12; /**< Constant to define Bit 12 on GPIO 1 */
+
+extern const hal_gpio_bit_t HAL_GPIO2_0; /**< Constant to define Bit 0 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_1; /**< Constant to define Bit 1 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_2; /**< Constant to define Bit 2 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_3; /**< Constant to define Bit 3 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_4; /**< Constant to define Bit 4 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_5; /**< Constant to define Bit 5 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_6; /**< Constant to define Bit 6 on GPIO 2 */
+
+extern const hal_gpio_bit_t HAL_GPIO3_0;  /**< Constant to define Bit 0 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_1;  /**< Constant to define Bit 1 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_2;  /**< Constant to define Bit 2 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_3;  /**< Constant to define Bit 3 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_4;  /**< Constant to define Bit 4 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_5;  /**< Constant to define Bit 5 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_6;  /**< Constant to define Bit 6 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_7;  /**< Constant to define Bit 7 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_8;  /**< Constant to define Bit 8 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_12; /**< Constant to define Bit 12 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_13; /**< Constant to define Bit 13 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_14; /**< Constant to define Bit 14 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_15; /**< Constant to define Bit 15 on GPIO 3 */
+
+extern const hal_gpio_bit_t HAL_GPIO4_11; /**< Constant to define Bit 11 on GPIO 4 */
+
+extern const hal_gpio_bit_t HAL_GPIO5_0;  /**< Constant to define Bit 0 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_1;  /**< Constant to define Bit 1 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_2;  /**< Constant to define Bit 2 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_3;  /**< Constant to define Bit 3 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_4;  /**< Constant to define Bit 4 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_8;  /**< Constant to define Bit 8 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_9;  /**< Constant to define Bit 9 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_12; /**< Constant to define Bit 12 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_13; /**< Constant to define Bit 13 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_14; /**< Constant to define Bit 14 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_15; /**< Constant to define Bit 15 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_16; /**< Constant to define Bit 16 on GPIO 5 */
+extern const hal_gpio_bit_t HAL_GPIO5_18; /**< Constant to define Bit 18 on GPIO 5 */
+/** @endcond */
+
+/* === Public function declarations ============================================================ */
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* SOC_GPIO_H */

--- a/module/hal/soc/lpc43xx/inc/soc_pin.h
+++ b/module/hal/soc/lpc43xx/inc/soc_pin.h
@@ -1,0 +1,160 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef SOC_PIN_H
+#define SOC_PIN_H
+
+/** @file
+ ** @brief Chip pins on lpc43xx declarations
+ **
+ ** @addtogroup lpc43xx LPC43xx
+ ** @ingroup hal
+ ** @brief LPC43xx SOC Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include "hal_pin.h"
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/* === Public variable declarations ============================================================ */
+
+/** @cond !INTERNAL */
+extern const hal_chip_pin_t HAL_PIN_P0_0; /**< Constant to define Pin 0 on chip port 0 */
+extern const hal_chip_pin_t HAL_PIN_P0_1; /**< Constant to define Pin 1 on chip port 0 */
+
+extern const hal_chip_pin_t HAL_PIN_P1_0;  /**< Constant to define Pin 0 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_1;  /**< Constant to define Pin 1 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_2;  /**< Constant to define Pin 2 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_3;  /**< Constant to define Pin 3 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_4;  /**< Constant to define Pin 4 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_5;  /**< Constant to define Pin 5 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_6;  /**< Constant to define Pin 6 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_7;  /**< Constant to define Pin 7 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_8;  /**< Constant to define Pin 8 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_9;  /**< Constant to define Pin 9 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_10; /**< Constant to define Pin 10 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_11; /**< Constant to define Pin 11 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_12; /**< Constant to define Pin 12 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_13; /**< Constant to define Pin 13 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_14; /**< Constant to define Pin 14 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_15; /**< Constant to define Pin 15 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_16; /**< Constant to define Pin 16 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_17; /**< Constant to define Pin 17 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_18; /**< Constant to define Pin 18 on chip port 1 */
+extern const hal_chip_pin_t HAL_PIN_P1_20; /**< Constant to define Pin 20 on chip port 1 */
+
+extern const hal_chip_pin_t HAL_PIN_P2_0;  /**< Constant to define Pin 0 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_1;  /**< Constant to define Pin 1 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_2;  /**< Constant to define Pin 2 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_3;  /**< Constant to define Pin 3 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_4;  /**< Constant to define Pin 4 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_5;  /**< Constant to define Pin 5 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_6;  /**< Constant to define Pin 6 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_7;  /**< Constant to define Pin 7 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_8;  /**< Constant to define Pin 8 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_9;  /**< Constant to define Pin 9 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_10; /**< Constant to define Pin 10 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_11; /**< Constant to define Pin 11 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_12; /**< Constant to define Pin 12 on chip port 2 */
+extern const hal_chip_pin_t HAL_PIN_P2_13; /**< Constant to define Pin 13 on chip port 2 */
+
+extern const hal_chip_pin_t HAL_PIN_P3_1; /**< Constant to define Pin 1 on chip port 3 */
+extern const hal_chip_pin_t HAL_PIN_P3_2; /**< Constant to define Pin 2 on chip port 3 */
+extern const hal_chip_pin_t HAL_PIN_P3_3; /**< Constant to define Pin 3 on chip port 3 */
+extern const hal_chip_pin_t HAL_PIN_P3_4; /**< Constant to define Pin 4 on chip port 3 */
+extern const hal_chip_pin_t HAL_PIN_P3_5; /**< Constant to define Pin 5 on chip port 3 */
+extern const hal_chip_pin_t HAL_PIN_P3_6; /**< Constant to define Pin 6 on chip port 3 */
+extern const hal_chip_pin_t HAL_PIN_P3_7; /**< Constant to define Pin 7 on chip port 3 */
+extern const hal_chip_pin_t HAL_PIN_P3_8; /**< Constant to define Pin 8 on chip port 3 */
+
+extern const hal_chip_pin_t HAL_PIN_P4_0;  /**< Constant to define Pin 0 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_1;  /**< Constant to define Pin 1 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_2;  /**< Constant to define Pin 2 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_3;  /**< Constant to define Pin 3 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_4;  /**< Constant to define Pin 4 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_5;  /**< Constant to define Pin 5 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_6;  /**< Constant to define Pin 6 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_7;  /**< Constant to define Pin 7 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_8;  /**< Constant to define Pin 8 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_9;  /**< Constant to define Pin 9 on chip port 4 */
+extern const hal_chip_pin_t HAL_PIN_P4_10; /**< Constant to define Pin 10 on chip port 4 */
+
+extern const hal_chip_pin_t HAL_PIN_P5_1; /**< Constant to define Pin 1 on chip port 5 */
+extern const hal_chip_pin_t HAL_PIN_P5_2; /**< Constant to define Pin 2 on chip port 5 */
+extern const hal_chip_pin_t HAL_PIN_P5_3; /**< Constant to define Pin 3 on chip port 5 */
+extern const hal_chip_pin_t HAL_PIN_P5_4; /**< Constant to define Pin 4 on chip port 5 */
+extern const hal_chip_pin_t HAL_PIN_P5_5; /**< Constant to define Pin 5 on chip port 5 */
+extern const hal_chip_pin_t HAL_PIN_P5_6; /**< Constant to define Pin 6 on chip port 5 */
+extern const hal_chip_pin_t HAL_PIN_P5_7; /**< Constant to define Pin 7 on chip port 5 */
+
+extern const hal_chip_pin_t HAL_PIN_P6_0;  /**< Constant to define Pin 0 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_1;  /**< Constant to define Pin 1 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_2;  /**< Constant to define Pin 2 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_3;  /**< Constant to define Pin 3 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_4;  /**< Constant to define Pin 4 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_5;  /**< Constant to define Pin 5 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_6;  /**< Constant to define Pin 6 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_7;  /**< Constant to define Pin 7 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_8;  /**< Constant to define Pin 8 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_9;  /**< Constant to define Pin 9 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_10; /**< Constant to define Pin 10 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_11; /**< Constant to define Pin 11 on chip port 6 */
+extern const hal_chip_pin_t HAL_PIN_P6_12; /**< Constant to define Pin 12 on chip port 6 */
+
+extern const hal_chip_pin_t HAL_PIN_P7_0; /**< Constant to define Pin 0 on chip port 7 */
+extern const hal_chip_pin_t HAL_PIN_P7_1; /**< Constant to define Pin 1 on chip port 7 */
+extern const hal_chip_pin_t HAL_PIN_P7_2; /**< Constant to define Pin 2 on chip port 7 */
+extern const hal_chip_pin_t HAL_PIN_P7_4; /**< Constant to define Pin 4 on chip port 7 */
+extern const hal_chip_pin_t HAL_PIN_P7_5; /**< Constant to define Pin 5 on chip port 7 */
+extern const hal_chip_pin_t HAL_PIN_P7_6; /**< Constant to define Pin 6 on chip port 7 */
+extern const hal_chip_pin_t HAL_PIN_P7_7; /**< Constant to define Pin 7 on chip port 7 */
+
+extern const hal_chip_pin_t HAL_PIN_P9_5; /**< Constant to define Pin 5 on chip port 9 */
+extern const hal_chip_pin_t HAL_PIN_P9_6; /**< Constant to define Pin 6 on chip port 9 */
+
+extern const hal_chip_pin_t HAL_PIN_PF_4; /**< Constant to define Pin 4 on chip port F */
+/** @endcond */
+
+/* === Public function declarations ============================================================ */
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* SOC_PIN_H */

--- a/module/hal/soc/lpc43xx/inc/soc_sci.h
+++ b/module/hal/soc/lpc43xx/inc/soc_sci.h
@@ -23,26 +23,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 SPDX-License-Identifier: MIT
 *************************************************************************************************/
 
-#ifndef HAL_H
-#define HAL_H
+#ifndef SOC_SCI_H
+#define SOC_SCI_H
 
 /** @file
- ** @brief Harware abstraction layer declarations
+ ** @brief Serial portson lpc43xx declarations
  **
- ** @addtogroup hal HAL
- ** @brief Hardware abstraction layer
+ ** @addtogroup lpc43xx LPC43xx
+ ** @ingroup hal
+ ** @brief LPC43xx SOC Hardware abstraction layer
  ** @{ */
 
 /* === Headers files inclusions ================================================================ */
 
-#include "hal_pin.h"
 #include "hal_sci.h"
-#include "hal_gpio.h"
-#include "hal_tick.h"
-#include "soc_pin.h"
-#include "soc_sci.h"
-#include "soc_gpio.h"
-#include "soc_tick.h"
 
 /* === Cabecera C++ ============================================================================ */
 
@@ -56,6 +50,13 @@ extern "C" {
 
 /* === Public variable declarations ============================================================ */
 
+/** @cond !INTERNAL */
+extern const hal_sci_t HAL_SCI_USART0; /**< Constant to define serial port 0 */
+extern const hal_sci_t HAL_SCI_UART1;  /**< Constant to define serial port 1 */
+extern const hal_sci_t HAL_SCI_USART2; /**< Constant to define serial port 2 */
+extern const hal_sci_t HAL_SCI_USART4; /**< Constant to define serial port 3 */
+/** @endcond */
+
 /* === Public function declarations ============================================================ */
 
 /* === End of documentation ==================================================================== */
@@ -66,4 +67,4 @@ extern "C" {
 
 /** @} End of module definition for doxygen */
 
-#endif /* HAL_H */
+#endif /* SOC_SCI_H */

--- a/module/hal/soc/lpc43xx/inc/soc_tick.h
+++ b/module/hal/soc/lpc43xx/inc/soc_tick.h
@@ -1,0 +1,63 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef SOC_TICK_H
+#define SOC_TICK_H
+
+/** @file
+ ** @brief System timer on lpc43xx declarations
+ **
+ ** @addtogroup lpc43xx LPC43xx
+ ** @ingroup hal
+ ** @brief LPC43xx SOC Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include "hal_tick.h"
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/* === Public variable declarations ============================================================ */
+
+/* === Public function declarations ============================================================ */
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* SOC_TICK_H */

--- a/module/hal/soc/lpc43xx/src/soc_gpio.c
+++ b/module/hal/soc/lpc43xx/src/soc_gpio.c
@@ -1,0 +1,196 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+/** @file
+ ** @brief Digital inputs/outputs on lpc43xx implementation
+ **
+ ** @addtogroup lpc43xx LPC43xx
+ ** @ingroup hal
+ ** @brief LPC43xx SOC Hardware abstraction layer
+ ** @cond INTERNAL
+ ** @{ */
+
+/* === Headers files inclusions =============================================================== */
+
+#include "soc_gpio.h"
+#include "chip.h"
+
+/* === Macros definitions ====================================================================== */
+
+/**
+ * @brief Macro to generate the name of an descriptor from the gpio port and bit
+ */
+#define GPIO_NAME(PORT, BIT) HAL_GPIO##PORT##_##BIT
+
+/**
+ * @brief Macro to define an gpio descriptor
+ */
+#define GPIO_BIT(PORT, PIN, FUNC, GPIO, BIT)                                                       \
+    GPIO_NAME(GPIO, BIT) = &(struct hal_gpio_bit_s) {                                              \
+        .gpio = GPIO, .bit = BIT, .function = FUNC, .port = PORT, .pin = PIN                       \
+    }
+
+/* === Private data type declarations ========================================================== */
+
+/**
+ * @brief Structure with the gpio terminal descriptor
+ */
+struct hal_gpio_bit_s {
+    uint8_t gpio : 3;     /**< Number of GPIO port */
+    uint8_t bit : 5;      /**< Number of GPIO terminal in port */
+    uint8_t function : 3; /**< Function to be assigned for use as a gpio terminal */
+    uint8_t pin : 5;      /**< Number of terminals port */
+    uint8_t port : 4;     /**< Number of pin in terminal port */
+};
+
+/* === Private variable declarations =========================================================== */
+
+/* === Private function declarations =========================================================== */
+
+/* === Public variable definitions ============================================================= */
+
+/**
+ * @addtogroup lpc43xxGpio GPIO Constants
+ * @brief Constant for gpio terminals on board
+ * @{
+ */
+const hal_gpio_bit_t GPIO_BIT(0, 0, 0, 0, 0); /**< Constant to define Bit 0 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(0, 1, 0, 0, 1); /**< Constant to define Bit 1 on GPIO 0 */
+
+const hal_gpio_bit_t GPIO_BIT(1, 0, 0, 0, 4);   /**< Constant to define Bit 4 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 1, 0, 0, 8);   /**< Constant to define Bit 8 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 2, 0, 0, 9);   /**< Constant to define Bit 9 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 3, 0, 0, 10);  /**< Constant to define Bit 10 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 4, 0, 0, 11);  /**< Constant to define Bit 11 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 5, 0, 1, 8);   /**< Constant to define Bit 8 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 6, 0, 1, 9);   /**< Constant to define Bit 9 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 15, 0, 0, 2);  /**< Constant to define Bit 2 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 16, 0, 0, 3);  /**< Constant to define Bit 3 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 17, 0, 0, 12); /**< Constant to define Bit 12 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 18, 0, 0, 13); /**< Constant to define Bit 13 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(1, 20, 0, 0, 15); /**< Constant to define Bit 15 on GPIO 0 */
+
+const hal_gpio_bit_t GPIO_BIT(2, 0, 4, 5, 0);   /**< Constant to define Bit 0 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(2, 1, 4, 5, 1);   /**< Constant to define Bit 1 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(2, 2, 4, 5, 2);   /**< Constant to define Bit 2 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(2, 3, 4, 5, 3);   /**< Constant to define Bit 3 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(2, 4, 4, 5, 4);   /**< Constant to define Bit 4 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(2, 7, 0, 0, 7);   /**< Constant to define Bit 7 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(2, 10, 0, 0, 14); /**< Constant to define Bit 14 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(2, 11, 0, 1, 11); /**< Constant to define Bit 11 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(2, 12, 0, 1, 12); /**< Constant to define Bit 12 on GPIO 1 */
+
+const hal_gpio_bit_t GPIO_BIT(3, 1, 4, 5, 8);   /**< Constant to define Bit 8 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(3, 2, 4, 5, 9);   /**< Constant to define Bit 9 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(4, 8, 4, 5, 12);  /**< Constant to define Bit 12 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(4, 9, 4, 5, 13);  /**< Constant to define Bit 13 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(4, 10, 4, 5, 14); /**< Constant to define Bit 14 on GPIO 5 */
+
+const hal_gpio_bit_t GPIO_BIT(4, 0, 0, 2, 0); /**< Constant to define Bit 0 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(4, 1, 0, 2, 1); /**< Constant to define Bit 1 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(4, 2, 0, 2, 2); /**< Constant to define Bit 2 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(4, 3, 0, 2, 3); /**< Constant to define Bit 3 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(4, 4, 0, 2, 4); /**< Constant to define Bit 4 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(4, 5, 0, 2, 5); /**< Constant to define Bit 5 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(4, 6, 0, 2, 6); /**< Constant to define Bit 6 on GPIO 2 */
+
+const hal_gpio_bit_t GPIO_BIT(6, 1, 0, 3, 0);  /**< Constant to define Bit 0 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(6, 2, 0, 3, 1);  /**< Constant to define Bit 1 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(6, 3, 0, 3, 2);  /**< Constant to define Bit 2 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(6, 4, 0, 3, 3);  /**< Constant to define Bit 3 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(6, 5, 0, 3, 4);  /**< Constant to define Bit 4 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(6, 6, 0, 0, 5);  /**< Constant to define Bit 5 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(6, 7, 4, 5, 15); /**< Constant to define Bit 15 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(6, 8, 4, 5, 16); /**< Constant to define Bit 16 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(6, 9, 0, 3, 5);  /**< Constant to define Bit 5 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(6, 10, 0, 3, 6); /**< Constant to define Bit 6 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(6, 11, 0, 3, 7); /**< Constant to define Bit 7 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(6, 12, 0, 2, 8); /**< Constant to define Bit 8 on GPIO 2 */
+
+const hal_gpio_bit_t GPIO_BIT(7, 4, 0, 2, 12); /**< Constant to define Bit 12 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(7, 5, 0, 2, 13); /**< Constant to define Bit 13 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(7, 6, 0, 2, 14); /**< Constant to define Bit 14 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(7, 7, 0, 2, 15); /**< Constant to define Bit 15 on GPIO 2 */
+
+const hal_gpio_bit_t GPIO_BIT(9, 5, 4, 5, 18); /**< Constant to define Bit 18 on GPIO 5 */
+const hal_gpio_bit_t GPIO_BIT(9, 6, 0, 4, 11); /**< Constant to define Bit 11 on GPIO 4 */
+/** @} End of group lpc43xxGpio */
+
+/* === Private variable definitions ============================================================ */
+
+/* === Private function implementation ========================================================= */
+
+/* === Public function implementation ========================================================== */
+
+void GpioSetDirection(hal_gpio_bit_t gpio, bool output) {
+    uint32_t value;
+
+    if (output) {
+        value = SCU_MODE_INACT | SCU_MODE_INBUFF_EN | SCU_MODE_ZIF_DIS;
+    } else {
+        value = SCU_MODE_PULLUP | SCU_MODE_INBUFF_EN | SCU_MODE_ZIF_DIS;
+    }
+    if (gpio) {
+        Chip_SCU_PinMux(gpio->port, gpio->pin, value, gpio->function);
+        Chip_GPIO_SetPinDIR(LPC_GPIO_PORT, gpio->gpio, gpio->bit, output);
+    }
+}
+
+bool GpioGetState(hal_gpio_bit_t gpio) {
+    bool value = false;
+    if (gpio) {
+        value = Chip_GPIO_ReadPortBit(LPC_GPIO_PORT, gpio->gpio, gpio->bit);
+    }
+    return value;
+}
+
+void GpioSetState(hal_gpio_bit_t gpio, bool state) {
+    if (gpio) {
+        Chip_GPIO_SetPinState(LPC_GPIO_PORT, gpio->gpio, gpio->bit, state);
+    }
+}
+
+void GpioBitSet(hal_gpio_bit_t gpio) {
+    if (gpio) {
+        Chip_GPIO_SetPinState(LPC_GPIO_PORT, gpio->gpio, gpio->bit, true);
+    }
+}
+
+void GpioBitClear(hal_gpio_bit_t gpio) {
+    if (gpio) {
+        Chip_GPIO_SetPinState(LPC_GPIO_PORT, gpio->gpio, gpio->bit, false);
+    }
+}
+
+void GpioBitToogle(hal_gpio_bit_t gpio) {
+    if (gpio) {
+        Chip_GPIO_SetPinToggle(LPC_GPIO_PORT, gpio->gpio, gpio->bit);
+    }
+}
+
+/* === End of documentation ==================================================================== */
+
+/** @} End of module definition for doxygen
+ ** @endcond */

--- a/module/hal/soc/lpc43xx/src/soc_pin.c
+++ b/module/hal/soc/lpc43xx/src/soc_pin.c
@@ -1,0 +1,223 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+/** @file
+ ** @brief Chip pins on lpc43xx implementation
+ **
+ ** @addtogroup lpc43xx LPC43xx
+ ** @ingroup hal
+ ** @brief LPC43xx SOC Hardware abstraction layer
+ ** @cond INTERNAL
+ ** @{ */
+
+/* === Headers files inclusions =============================================================== */
+
+#include "soc_pin.h"
+#include "chip.h"
+
+/* === Macros definitions ====================================================================== */
+
+/**
+ * @brief Macro to generate the name of an descriptor from the gpio port and bit
+ */
+#define PIN_NAME(PORT, PIN) HAL_PIN_P##PORT##_##PIN
+
+/**
+ * @brief Macro to define an gpio descriptor
+ */
+#define CHIP_PIN(PORT, PIN)                                                                        \
+    PIN_NAME(PORT, PIN) = &(struct hal_chip_pin_s) { .port = PORT, .pin = PIN }
+
+/* === Private data type declarations ========================================================== */
+
+/**
+ * @brief Structure with the gpio terminal descriptor
+ */
+struct hal_chip_pin_s {
+    uint8_t pin : 5;  /**< Number of chip pin port */
+    uint8_t port : 4; /**< Number of pin in chip port */
+};
+
+/* === Private variable declarations =========================================================== */
+
+/* === Private function declarations =========================================================== */
+
+/* === Public variable definitions ============================================================= */
+
+/**
+ * @addtogroup lpc43xxPin PIN Constants
+ * @brief Constant for chip pin on board
+ * @{
+ */
+const hal_chip_pin_t CHIP_PIN(0, 0); /**< Constant to define Pin 0 on chip port 0 */
+const hal_chip_pin_t CHIP_PIN(0, 1); /**< Constant to define Pin 1 on chip port 0 */
+
+const hal_chip_pin_t CHIP_PIN(1, 0);  /**< Constant to define Pin 0 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 1);  /**< Constant to define Pin 1 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 2);  /**< Constant to define Pin 2 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 3);  /**< Constant to define Pin 3 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 4);  /**< Constant to define Pin 4 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 5);  /**< Constant to define Pin 5 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 6);  /**< Constant to define Pin 6 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 7);  /**< Constant to define Pin 7 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 8);  /**< Constant to define Pin 8 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 9);  /**< Constant to define Pin 9 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 10); /**< Constant to define Pin 10 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 11); /**< Constant to define Pin 11 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 12); /**< Constant to define Pin 12 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 13); /**< Constant to define Pin 13 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 14); /**< Constant to define Pin 14 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 15); /**< Constant to define Pin 15 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 16); /**< Constant to define Pin 16 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 17); /**< Constant to define Pin 17 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 18); /**< Constant to define Pin 18 on chip port 1 */
+const hal_chip_pin_t CHIP_PIN(1, 20); /**< Constant to define Pin 20 on chip port 1 */
+
+const hal_chip_pin_t CHIP_PIN(2, 0);  /**< Constant to define Pin 0 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 1);  /**< Constant to define Pin 1 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 2);  /**< Constant to define Pin 2 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 3);  /**< Constant to define Pin 3 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 4);  /**< Constant to define Pin 4 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 5);  /**< Constant to define Pin 5 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 6);  /**< Constant to define Pin 6 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 7);  /**< Constant to define Pin 7 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 8);  /**< Constant to define Pin 8 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 9);  /**< Constant to define Pin 9 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 10); /**< Constant to define Pin 10 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 11); /**< Constant to define Pin 11 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 12); /**< Constant to define Pin 12 on chip port 2 */
+const hal_chip_pin_t CHIP_PIN(2, 13); /**< Constant to define Pin 13 on chip port 2 */
+
+const hal_chip_pin_t CHIP_PIN(3, 1); /**< Constant to define Pin 1 on chip port 3 */
+const hal_chip_pin_t CHIP_PIN(3, 2); /**< Constant to define Pin 2 on chip port 3 */
+const hal_chip_pin_t CHIP_PIN(3, 3); /**< Constant to define Pin 3 on chip port 3 */
+const hal_chip_pin_t CHIP_PIN(3, 4); /**< Constant to define Pin 4 on chip port 3 */
+const hal_chip_pin_t CHIP_PIN(3, 5); /**< Constant to define Pin 5 on chip port 3 */
+const hal_chip_pin_t CHIP_PIN(3, 6); /**< Constant to define Pin 6 on chip port 3 */
+const hal_chip_pin_t CHIP_PIN(3, 7); /**< Constant to define Pin 7 on chip port 3 */
+const hal_chip_pin_t CHIP_PIN(3, 8); /**< Constant to define Pin 8 on chip port 3 */
+
+const hal_chip_pin_t CHIP_PIN(4, 0);  /**< Constant to define Pin 0 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 1);  /**< Constant to define Pin 1 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 2);  /**< Constant to define Pin 2 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 3);  /**< Constant to define Pin 3 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 4);  /**< Constant to define Pin 4 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 5);  /**< Constant to define Pin 5 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 6);  /**< Constant to define Pin 6 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 7);  /**< Constant to define Pin 7 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 8);  /**< Constant to define Pin 8 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 9);  /**< Constant to define Pin 9 on chip port 4 */
+const hal_chip_pin_t CHIP_PIN(4, 10); /**< Constant to define Pin 10 on chip port 4 */
+
+const hal_chip_pin_t CHIP_PIN(5, 1); /**< Constant to define Pin 1 on chip port 5 */
+const hal_chip_pin_t CHIP_PIN(5, 2); /**< Constant to define Pin 2 on chip port 5 */
+const hal_chip_pin_t CHIP_PIN(5, 3); /**< Constant to define Pin 3 on chip port 5 */
+const hal_chip_pin_t CHIP_PIN(5, 4); /**< Constant to define Pin 4 on chip port 5 */
+const hal_chip_pin_t CHIP_PIN(5, 5); /**< Constant to define Pin 5 on chip port 5 */
+const hal_chip_pin_t CHIP_PIN(5, 6); /**< Constant to define Pin 6 on chip port 5 */
+const hal_chip_pin_t CHIP_PIN(5, 7); /**< Constant to define Pin 7 on chip port 5 */
+
+const hal_chip_pin_t CHIP_PIN(6, 0);  /**< Constant to define Pin 0 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 1);  /**< Constant to define Pin 1 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 2);  /**< Constant to define Pin 2 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 3);  /**< Constant to define Pin 3 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 4);  /**< Constant to define Pin 4 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 5);  /**< Constant to define Pin 5 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 6);  /**< Constant to define Pin 6 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 7);  /**< Constant to define Pin 7 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 8);  /**< Constant to define Pin 8 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 9);  /**< Constant to define Pin 9 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 10); /**< Constant to define Pin 10 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 11); /**< Constant to define Pin 11 on chip port 6 */
+const hal_chip_pin_t CHIP_PIN(6, 12); /**< Constant to define Pin 12 on chip port 6 */
+
+const hal_chip_pin_t CHIP_PIN(7, 0); /**< Constant to define Pin 0 on chip port 7 */
+const hal_chip_pin_t CHIP_PIN(7, 1); /**< Constant to define Pin 1 on chip port 7 */
+const hal_chip_pin_t CHIP_PIN(7, 2); /**< Constant to define Pin 2 on chip port 7 */
+const hal_chip_pin_t CHIP_PIN(7, 4); /**< Constant to define Pin 4 on chip port 7 */
+const hal_chip_pin_t CHIP_PIN(7, 5); /**< Constant to define Pin 5 on chip port 7 */
+const hal_chip_pin_t CHIP_PIN(7, 6); /**< Constant to define Pin 6 on chip port 7 */
+const hal_chip_pin_t CHIP_PIN(7, 7); /**< Constant to define Pin 7 on chip port 7 */
+
+const hal_chip_pin_t CHIP_PIN(9, 5); /**< Constant to define Pin 5 on chip port 9 */
+const hal_chip_pin_t CHIP_PIN(9, 6); /**< Constant to define Pin 6 on chip port 9 */
+
+/** Constant to define Pin 4 on chip port F */
+const hal_chip_pin_t HAL_PIN_PF_4 = &(struct hal_chip_pin_s){.port = 15, .pin = 4};
+
+/** @} End of group lpc43xxPin */
+
+/* === Private variable definitions ============================================================ */
+
+/* === Private function implementation ========================================================= */
+
+/* === Public function implementation ========================================================== */
+
+void ChipPinSetFunction(hal_chip_pin_t pin, uint8_t function, bool pullup, bool puldown) {
+    uint32_t value;
+
+    value = SCU_MODE_INBUFF_EN | SCU_MODE_ZIF_DIS;
+
+    if (pullup && puldown) {
+        value |= SCU_MODE_REPEATER;
+    } else if (pullup) {
+        value |= SCU_MODE_PULLUP;
+    } else if (puldown) {
+        value |= SCU_MODE_PULLDOWN;
+    } else {
+        value |= SCU_MODE_INACT;
+    }
+
+    Chip_SCU_PinMux(pin->port, pin->pin, value, function);
+}
+
+void ChipPinSetPullUp(hal_chip_pin_t pin, bool enable) {
+    uint32_t current;
+
+    current = LPC_SCU->SFSP[pin->port][pin->pin];
+    if (enable) {
+        current &= ~(1 << 3);
+    } else {
+        current |= (1 << 3);
+    }
+    Chip_SCU_PinMuxSet(pin->port, pin->pin, current);
+}
+
+void ChipPinSetPullDown(hal_chip_pin_t pin, bool enable) {
+    uint32_t current;
+
+    current = LPC_SCU->SFSP[pin->port][pin->pin];
+    if (enable) {
+        current |= (1 << 4);
+    } else {
+        current &= ~(1 << 4);
+    }
+    Chip_SCU_PinMuxSet(pin->port, pin->pin, current);
+}
+
+/* === End of documentation ==================================================================== */
+
+/** @} End of module definition for doxygen
+ ** @endcond */

--- a/module/hal/soc/lpc43xx/src/soc_sci.c
+++ b/module/hal/soc/lpc43xx/src/soc_sci.c
@@ -1,0 +1,429 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+/** @file
+ ** @brief Serial ports on lpc43xx implementation
+ **
+ ** @addtogroup lpc43xx LPC43xx
+ ** @ingroup hal
+ ** @brief LPC43xx SOC Hardware abstraction layer
+ ** @cond INTERNAL
+ ** @{ */
+
+/* === Headers files inclusions =============================================================== */
+
+#include "soc_sci.h"
+#include "soc_pin.h"
+#include "chip.h"
+
+/* === Macros definitions ====================================================================== */
+
+/* === Private data type declarations ========================================================== */
+
+/**
+ * @brief Strcuture to store a serial port descriptor
+ */
+struct hal_sci_s {
+    LPC_USART_T * port; /**< Pointer to the memory area with the serial port registers */
+    IRQn_Type interupt; /**< Interrupt number corresponding to the serial port */
+    uint8_t index;      /**< Numeric index of serial port */
+};
+
+/**
+ * @brief Structure to store a serial port event handler
+ */
+typedef struct event_handler_s {
+    hal_sci_event_t handler; /**< Function to call on the serial port events */
+    void * data;             /**< Pointer to user data sended as parameter in handler calls */
+} * event_handler_t;
+
+/* === Private variable declarations =========================================================== */
+
+/* === Private function declarations ===========================================================  */
+
+/**
+ * @brief Function to validate and configurate chip pins used by serial port USART0
+ *
+ * @param   pins    Pointer to structure with chip pins asigned to serial port
+ * @return  true    The configuration is valid and has been applied
+ * @return  false   The configuration is invalid and has not been applied
+ */
+static bool ConfigPinsUsart0(hal_sci_pins_t pins);
+
+/**
+ * @brief Function to validate and configurate chip pins used by serial port UART1
+ *
+ * @param   pins    Pointer to structure with chip pins asigned to serial port
+ * @return  true    The configuration is valid and has been applied
+ * @return  false   The configuration is invalid and has not been applied
+ */
+static bool ConfigPinsUart1(hal_sci_pins_t pins);
+
+/**
+ * @brief Function to validate and configurate chip pins used by serial port USART2
+ *
+ * @param   pins    Pointer to structure with chip pins asigned to serial port
+ * @return  true    The configuration is valid and has been applied
+ * @return  false   The configuration is invalid and has not been applied
+ */
+static bool ConfigPinsUsart2(hal_sci_pins_t pins);
+
+/**
+ * @brief Function to validate and configurate chip pins used by serial port USART3
+ *
+ * @param   pins    Pointer to structure with chip pins asigned to serial port
+ * @return  true    The configuration is valid and has been applied
+ * @return  false   The configuration is invalid and has not been applied
+ */
+static bool ConfigPinsUsart3(hal_sci_pins_t pins);
+
+/**
+ * @brief Function to encode serial port line parameters as bits required by control register
+ *
+ * @param   line      Pointer to structure with serial port line parameters
+ * @return  uint32_t  Field of bits as defined in control register of serial port
+ */
+static uint32_t LineEncodeBits(hal_sci_line_t line);
+
+/**
+ * @brief Function to dispatch an sci port event when the device raises an interrupt
+ *
+ * @param  sci  Pointer to the structure with the serial port descriptor
+ */
+static void SciHandleEvent(hal_sci_t sci);
+
+/* === Public variable definitions ============================================================= */
+
+/**
+ * @addtogroup lpc43xxSci USART Constants
+ * @brief Constant for serial ports on board
+ * @{
+ */
+
+/** Constant to define serial port 0 */
+const hal_sci_t HAL_SCI_USART0 =
+    &(struct hal_sci_s){.port = LPC_USART0, .interupt = USART0_IRQn, .index = 0};
+
+/** Constant to define serial port 1 */
+const hal_sci_t HAL_SCI_UART1 =
+    &(struct hal_sci_s){.port = LPC_UART1, .interupt = UART1_IRQn, .index = 1};
+
+/** Constant to define serial port 2 */
+const hal_sci_t HAL_SCI_USART2 =
+    &(struct hal_sci_s){.port = LPC_USART2, .interupt = USART2_IRQn, .index = 2};
+
+/** Constant to define serial port 3 */
+const hal_sci_t HAL_SCI_USART3 =
+    &(struct hal_sci_s){.port = LPC_USART3, .interupt = USART3_IRQn, .index = 3};
+
+/** @} End of group lpc43xxSci */
+
+/* === Private variable definitions ============================================================ */
+
+/**
+ * @brief Vector to store the event handlers of the serial ports
+ */
+static struct event_handler_s event_handlers[4] = {0};
+
+/* === Private function implementation ========================================================= */
+
+static bool ConfigPinsUsart0(hal_sci_pins_t pins) {
+    /*
+     * U0_TXD = (P2_0: F1), (P6_4: F2), (P9_5: F7), (PF_10: F1)
+     * U0_RXD = (P2_1: F1), (P6_5: F2), (P9_6: F7), (PF_11: F1)
+     */
+    uint8_t txd_function = 0xFF;
+    uint8_t rxd_function = 0xFF;
+    bool result = false;
+
+    if (pins->txd_pin == HAL_PIN_P2_0) {
+        txd_function = 1;
+    } else if (pins->txd_pin == HAL_PIN_P6_4) {
+        txd_function = 2;
+    } else if (pins->txd_pin == HAL_PIN_P9_5) {
+        txd_function = 7;
+    }
+
+    if (pins->rxd_pin == HAL_PIN_P2_1) {
+        rxd_function = 1;
+    } else if (pins->rxd_pin == HAL_PIN_P6_5) {
+        rxd_function = 2;
+    } else if (pins->rxd_pin == HAL_PIN_P9_6) {
+        rxd_function = 7;
+    }
+
+    if ((txd_function != 0xFF) && (rxd_function != 0xFF)) {
+        ChipPinSetFunction(pins->txd_pin, txd_function, false, false);
+        ChipPinSetFunction(pins->rxd_pin, rxd_function, true, false);
+        result = true;
+    }
+    return result;
+}
+
+static bool ConfigPinsUart1(hal_sci_pins_t pins) {
+    /*
+     * U1_TXD = (P1_13: F1), (P3_4: F4), (P5_6: F4), (PC_13: F2), (PE_11: F2)
+     * U1_RXD = (P1_14: F1), (P3_5: F4), (P5_7: F4), (PC_14: F2), (PE_12: F2)
+     */
+    uint8_t txd_function = 0xFF;
+    uint8_t rxd_function = 0xFF;
+    bool result = false;
+
+    if (pins->txd_pin == HAL_PIN_P1_13) {
+        txd_function = 1;
+    } else if (pins->txd_pin == HAL_PIN_P3_4) {
+        txd_function = 4;
+    } else if (pins->txd_pin == HAL_PIN_P5_6) {
+        txd_function = 4;
+    }
+
+    if (pins->rxd_pin == HAL_PIN_P1_14) {
+        rxd_function = 1;
+    } else if (pins->rxd_pin == HAL_PIN_P3_5) {
+        rxd_function = 4;
+    } else if (pins->rxd_pin == HAL_PIN_P5_7) {
+        rxd_function = 4;
+    }
+
+    if ((txd_function != 0xFF) && (rxd_function != 0xFF)) {
+        ChipPinSetFunction(pins->txd_pin, txd_function, false, false);
+        ChipPinSetFunction(pins->rxd_pin, rxd_function, true, false);
+        result = true;
+    }
+    return result;
+}
+
+static bool ConfigPinsUsart2(hal_sci_pins_t pins) {
+    /*
+     * U2_TXD = (P1_15: F1), (P2_10: F2), (P7_1: F6), (PA_1: F3)
+     * U2_RXD = (P1_16: F1), (P2_11: F2), (P7_2: F6), (PA_2: F3)
+     */
+    uint8_t txd_function = 0xFF;
+    uint8_t rxd_function = 0xFF;
+    bool result = false;
+
+    if (pins->txd_pin == HAL_PIN_P1_15) {
+        txd_function = 1;
+    } else if (pins->txd_pin == HAL_PIN_P2_10) {
+        txd_function = 2;
+    } else if (pins->txd_pin == HAL_PIN_P7_1) {
+        txd_function = 6;
+    }
+
+    if (pins->rxd_pin == HAL_PIN_P1_16) {
+        rxd_function = 1;
+    } else if (pins->rxd_pin == HAL_PIN_P2_11) {
+        rxd_function = 2;
+    } else if (pins->rxd_pin == HAL_PIN_P7_2) {
+        rxd_function = 6;
+    }
+
+    if ((txd_function != 0xFF) && (rxd_function != 0xFF)) {
+        ChipPinSetFunction(pins->txd_pin, txd_function, false, false);
+        ChipPinSetFunction(pins->rxd_pin, rxd_function, true, false);
+        result = true;
+    }
+    return result;
+}
+
+static bool ConfigPinsUsart3(hal_sci_pins_t pins) {
+    /*
+     * U2_TXD = (P2_3: F2), (P4_1: F6), (P9_3: F7), (PF_2: F1)
+     * U2_RXD = (P2_4: F2), (P4_2: F6), (P9_4: F7), (PF_3: F1)
+     */
+    uint8_t txd_function = 0xFF;
+    uint8_t rxd_function = 0xFF;
+    bool result = false;
+
+    if (pins->txd_pin == HAL_PIN_P2_3) {
+        txd_function = 2;
+    } else if (pins->txd_pin == HAL_PIN_P4_1) {
+        txd_function = 6;
+    }
+
+    if (pins->rxd_pin == HAL_PIN_P2_4) {
+        rxd_function = 2;
+    } else if (pins->rxd_pin == HAL_PIN_P4_2) {
+        rxd_function = 6;
+    }
+
+    if ((txd_function != 0xFF) && (rxd_function != 0xFF)) {
+        ChipPinSetFunction(pins->txd_pin, txd_function, false, false);
+        ChipPinSetFunction(pins->rxd_pin, rxd_function, true, false);
+        result = true;
+    }
+    return result;
+}
+
+static uint32_t LineEncodeBits(hal_sci_line_t line) {
+    uint32_t config;
+
+    config = UART_LCR_SBS_1BIT;
+    switch (line->data_bits) {
+    case 5:
+        config |= UART_LCR_WLEN5;
+        break;
+    case 6:
+        config |= UART_LCR_WLEN6;
+        break;
+    case 7:
+        config |= UART_LCR_WLEN7;
+        break;
+    default:
+        config |= UART_LCR_WLEN8;
+        break;
+    }
+
+    switch (line->parity) {
+    case HAL_SCI_ODD_PARITY:
+        config |= UART_LCR_PARITY_EN | UART_LCR_PARITY_ODD;
+        break;
+    case HAL_SCI_EVEN_PARITY:
+        config |= UART_LCR_PARITY_EN | UART_LCR_PARITY_EVEN;
+        break;
+    case HAL_SCI_MARK_PARITY:
+        config |= UART_LCR_PARITY_EN | UART_LCR_PARITY_F_1;
+        break;
+    case HAL_SCI_SPACE_PARITY:
+        config |= UART_LCR_PARITY_EN | UART_LCR_PARITY_F_0;
+        break;
+    default:
+        config |= UART_LCR_PARITY_DIS;
+        break;
+    }
+
+    return config;
+}
+
+static void SciHandleEvent(hal_sci_t sci) {
+    if (sci) {
+        event_handler_t event_handler = &event_handlers[sci->index];
+        struct sci_status_s status;
+
+        (void)Chip_UART_ReadIntIDReg(sci->port);
+
+        SciReadStatus(sci, &status);
+        if (event_handler->handler) {
+            event_handler->handler(sci, &status, event_handler->data);
+        }
+    }
+}
+
+/* === Public function implementation ========================================================== */
+
+bool SciSetConfig(hal_sci_t sci, hal_sci_line_t line, hal_sci_pins_t pins) {
+    bool result = false;
+
+    if (sci) {
+        switch (sci->index) {
+        case 0:
+            result = ConfigPinsUsart0(pins);
+            break;
+        case 1:
+            result = ConfigPinsUart1(pins);
+            break;
+        case 2:
+            result = ConfigPinsUsart2(pins);
+            break;
+        case 3:
+            result = ConfigPinsUsart3(pins);
+            break;
+        }
+
+        if (result) {
+            Chip_UART_Init(sci->port);
+            Chip_UART_SetBaud(sci->port, line->baud_rate);
+            Chip_UART_ConfigData(sci->port, LineEncodeBits(line));
+            Chip_UART_SetupFIFOS(sci->port, UART_FCR_FIFO_EN | UART_FCR_TRG_LEV0);
+            Chip_UART_TXEnable(sci->port);
+        }
+    }
+    return result;
+}
+
+uint16_t SciSendData(hal_sci_t sci, void const * const data, uint16_t size) {
+    uint16_t result = 0;
+    if (sci) {
+        result = Chip_UART_Send(sci->port, data, size);
+    }
+    return result;
+}
+
+uint16_t SciReceiveData(hal_sci_t sci, void * data, uint16_t size) {
+    uint16_t result = 0;
+    if (sci) {
+        result = Chip_UART_Read(sci->port, data, size);
+    }
+    return result;
+}
+
+void SciReadStatus(hal_sci_t sci, sci_status_t result) {
+    if (sci) {
+        uint32_t status = Chip_UART_ReadLineStatus(sci->port);
+        result->data_ready = status & UART_LSR_RDR;
+        result->overrun = status & UART_LSR_OE;
+        result->parity_error = status & UART_LSR_PE;
+        result->framing_error = status & UART_LSR_FE;
+        result->break_signal = status & UART_LSR_BI;
+        result->fifo_empty = status & UART_LSR_THRE;
+        result->tramition_completed = status & UART_LSR_TEMT;
+    }
+}
+
+void SciSetEventHandler(hal_sci_t sci, hal_sci_event_t handler, void * data) {
+    if (sci) {
+        event_handler_t event_handler = &event_handlers[sci->index];
+        event_handler->handler = handler;
+        event_handler->data = data;
+
+        Chip_UART_ReadLineStatus(sci->port);
+        NVIC_ClearPendingIRQ(sci->interupt);
+        NVIC_EnableIRQ(sci->interupt);
+        Chip_UART_IntEnable(sci->port, UART_IER_RBRINT);
+        Chip_UART_IntEnable(sci->port, UART_IER_THREINT);
+        Chip_UART_IntEnable(sci->port, UART_IER_RLSINT);
+    }
+}
+
+void UART0_IRQHandler(void) {
+    SciHandleEvent(HAL_SCI_USART0);
+}
+
+void UART1_IRQHandler(void) {
+    SciHandleEvent(HAL_SCI_UART1);
+}
+
+void UART2_IRQHandler(void) {
+    SciHandleEvent(HAL_SCI_USART2);
+}
+
+void UART3_IRQHandler(void) {
+    SciHandleEvent(HAL_SCI_USART3);
+}
+
+/* === End of documentation ==================================================================== */
+
+/** @} End of module definition for doxygen
+ ** @endcond */

--- a/module/hal/soc/lpc43xx/src/soc_tick.c
+++ b/module/hal/soc/lpc43xx/src/soc_tick.c
@@ -1,0 +1,93 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+/** @file
+ ** @brief System timer on lpc43xx implementation
+ **
+ ** @addtogroup lpc43xx LPC43xx
+ ** @ingroup hal
+ ** @brief LPC43xx SOC Hardware abstraction layer
+ ** @cond INTERNAL
+ ** @{ */
+
+/* === Headers files inclusions =============================================================== */
+
+#include "soc_tick.h"
+#include "chip.h"
+
+/* === Macros definitions ====================================================================== */
+
+/* === Private data type declarations ========================================================== */
+
+/**
+ * @brief Pointer to the structure with the system timer descriptor
+ */
+typedef struct hal_tick_s {
+    hal_tick_event_t handler; /**< Function to call on the system timer events */
+    void * object;            /**< Pointer to user data sended as parameter in handler calls */
+} * hal_tick_t;
+
+/* === Private variable declarations =========================================================== */
+
+/* === Private function declarations =========================================================== */
+
+/* === Public variable definitions ============================================================= */
+
+/* === Private variable definitions ============================================================ */
+
+/**
+ * @brief Variable with the instance of system timer descriptor
+ */
+static struct hal_tick_s instance[1] = {0};
+
+/* === Private function implementation ========================================================= */
+
+/* === Public function implementation ========================================================== */
+
+void TickStart(hal_tick_event_t handler, void * object, uint32_t period) {
+    __asm volatile("cpsid i");
+
+    instance->handler = handler;
+    instance->object = object;
+
+    /* Activate SysTick */
+    SystemCoreClockUpdate();
+    SysTick_Config((SystemCoreClock / 1000000) * period);
+
+    /* Update priority set by SysTick_Config */
+    NVIC_SetPriority(SysTick_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+
+    __asm volatile("cpsie i");
+}
+
+void SysTick_Handler(void) {
+    if (instance->handler) {
+        instance->handler(instance->object);
+    }
+}
+/* === End of documentation ==================================================================== */
+
+/** @} End of module definition for doxygen
+ ** @endcond */

--- a/module/hal/soc/posix/inc/soc_gpio.h
+++ b/module/hal/soc/posix/inc/soc_gpio.h
@@ -1,0 +1,101 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef SOC_GPIO_H
+#define SOC_GPIO_H
+
+/** @file
+ ** @brief Digital inputs/outputs on posix declarations
+ **
+ ** @addtogroup posix Posix
+ ** @ingroup hal
+ ** @brief Posix SOC Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include "hal_gpio.h"
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/* === Public variable declarations ============================================================ */
+
+/** @cond !INTERNAL */
+extern const hal_gpio_bit_t HAL_GPIO0_0; /**< Constant to define Bit 0 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_1; /**< Constant to define Bit 1 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_2; /**< Constant to define Bit 2 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_3; /**< Constant to define Bit 3 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_4; /**< Constant to define Bit 4 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_5; /**< Constant to define Bit 5 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_6; /**< Constant to define Bit 6 on GPIO 0 */
+extern const hal_gpio_bit_t HAL_GPIO0_7; /**< Constant to define Bit 7 on GPIO 0 */
+
+extern const hal_gpio_bit_t HAL_GPIO1_0; /**< Constant to define Bit 0 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_1; /**< Constant to define Bit 1 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_2; /**< Constant to define Bit 2 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_3; /**< Constant to define Bit 3 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_4; /**< Constant to define Bit 4 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_5; /**< Constant to define Bit 5 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_6; /**< Constant to define Bit 6 on GPIO 1 */
+extern const hal_gpio_bit_t HAL_GPIO1_7; /**< Constant to define Bit 7 on GPIO 1 */
+
+extern const hal_gpio_bit_t HAL_GPIO2_0; /**< Constant to define Bit 0 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_1; /**< Constant to define Bit 1 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_2; /**< Constant to define Bit 2 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_3; /**< Constant to define Bit 3 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_4; /**< Constant to define Bit 4 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_5; /**< Constant to define Bit 5 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_6; /**< Constant to define Bit 6 on GPIO 2 */
+extern const hal_gpio_bit_t HAL_GPIO2_7; /**< Constant to define Bit 7 on GPIO 2 */
+
+extern const hal_gpio_bit_t HAL_GPIO3_0; /**< Constant to define Bit 0 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_1; /**< Constant to define Bit 1 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_2; /**< Constant to define Bit 2 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_3; /**< Constant to define Bit 3 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_4; /**< Constant to define Bit 4 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_5; /**< Constant to define Bit 5 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_6; /**< Constant to define Bit 6 on GPIO 3 */
+extern const hal_gpio_bit_t HAL_GPIO3_7; /**< Constant to define Bit 7 on GPIO 3 */
+/** @endcond */
+
+/* === Public function declarations ============================================================ */
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* SOC_GPIO_H */

--- a/module/hal/soc/posix/inc/soc_pin.h
+++ b/module/hal/soc/posix/inc/soc_pin.h
@@ -23,26 +23,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 SPDX-License-Identifier: MIT
 *************************************************************************************************/
 
-#ifndef HAL_H
-#define HAL_H
+#ifndef SOC_PIN_H
+#define SOC_PIN_H
 
 /** @file
- ** @brief Harware abstraction layer declarations
+ ** @brief Chip pins on posix declarations
  **
- ** @addtogroup hal HAL
- ** @brief Hardware abstraction layer
+ ** @addtogroup posix Posix
+ ** @ingroup hal
+ ** @brief Posix SOC Hardware abstraction layer
  ** @{ */
 
 /* === Headers files inclusions ================================================================ */
 
 #include "hal_pin.h"
-#include "hal_sci.h"
-#include "hal_gpio.h"
-#include "hal_tick.h"
-#include "soc_pin.h"
-#include "soc_sci.h"
-#include "soc_gpio.h"
-#include "soc_tick.h"
 
 /* === Cabecera C++ ============================================================================ */
 
@@ -66,4 +60,4 @@ extern "C" {
 
 /** @} End of module definition for doxygen */
 
-#endif /* HAL_H */
+#endif /* SOC_PIN_H */

--- a/module/hal/soc/posix/inc/soc_sci.h
+++ b/module/hal/soc/posix/inc/soc_sci.h
@@ -23,26 +23,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 SPDX-License-Identifier: MIT
 *************************************************************************************************/
 
-#ifndef HAL_H
-#define HAL_H
+#ifndef SOC_SCI_H
+#define SOC_SCI_H
 
 /** @file
- ** @brief Harware abstraction layer declarations
+ ** @brief Serial ports on posix declarations
  **
- ** @addtogroup hal HAL
- ** @brief Hardware abstraction layer
+ ** @addtogroup posix Posix
+ ** @ingroup hal
+ ** @brief Posix SOC Hardware abstraction layer
  ** @{ */
 
 /* === Headers files inclusions ================================================================ */
 
-#include "hal_pin.h"
 #include "hal_sci.h"
-#include "hal_gpio.h"
-#include "hal_tick.h"
-#include "soc_pin.h"
-#include "soc_sci.h"
-#include "soc_gpio.h"
-#include "soc_tick.h"
 
 /* === Cabecera C++ ============================================================================ */
 
@@ -66,4 +60,4 @@ extern "C" {
 
 /** @} End of module definition for doxygen */
 
-#endif /* HAL_H */
+#endif /* SOC_SCI_H */

--- a/module/hal/soc/posix/inc/soc_tick.h
+++ b/module/hal/soc/posix/inc/soc_tick.h
@@ -1,0 +1,63 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+#ifndef SOC_TICK_H
+#define SOC_TICK_H
+
+/** @file
+ ** @brief System timer on posix declarations
+ **
+ ** @addtogroup posix Posix
+ ** @ingroup hal
+ ** @brief Posix SOC Hardware abstraction layer
+ ** @{ */
+
+/* === Headers files inclusions ================================================================ */
+
+#include "hal_tick.h"
+
+/* === Cabecera C++ ============================================================================ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* === Public macros definitions =============================================================== */
+
+/* === Public data type declarations =========================================================== */
+
+/* === Public variable declarations ============================================================ */
+
+/* === Public function declarations ============================================================ */
+
+/* === End of documentation ==================================================================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} End of module definition for doxygen */
+
+#endif /* SOC_TICK_H */

--- a/module/hal/soc/posix/src/soc_gpio.c
+++ b/module/hal/soc/posix/src/soc_gpio.c
@@ -1,0 +1,250 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+/** @file
+ ** @brief Digital inputs/outputs on posix implementation
+ **
+ ** @addtogroup posix Posix
+ ** @ingroup hal
+ ** @brief Posix SOC Hardware abstraction layer
+ ** @cond INTERNAL
+ ** @{ */
+
+/* === Headers files inclusions =============================================================== */
+
+#include "soc_gpio.h"
+#include <stdio.h>
+#include <pthread.h>
+#include <termios.h>
+#include <unistd.h>
+
+/* === Macros definitions ====================================================================== */
+
+/**
+ * @brief Macro to generate the name of an descriptor from the gpio port and bit
+ */
+#define GPIO_NAME(PORT, BIT) HAL_GPIO##PORT##_##BIT
+
+/**
+ * @brief Macro to define an gpio descriptor
+ */
+#define GPIO_BIT(GPIO, BIT)                                                                        \
+    GPIO_NAME(GPIO, BIT) = &(struct hal_gpio_bit_s) { .gpio = GPIO, .bit = BIT }
+
+/* === Private data type declarations ========================================================== */
+
+/**
+ * @brief Structure with the gpio terminal descriptor
+ */
+struct hal_gpio_bit_s {
+    uint8_t gpio : 3; /**< Number of GPIO port */
+    uint8_t bit : 5;  /**< Number of GPIO terminal in port */
+};
+
+/* === Private variable declarations =========================================================== */
+
+/**
+ * @brief Variable to maintain the state of the emulated gpio terminals
+ */
+static uint8_t gpio_emulation[4];
+
+/* === Private function declarations =========================================================== */
+
+/**
+ * @brief Function to implement a main loop of a thread to scan keyboard
+ *
+ * @param _         Pointer to initial data, required by function prototype, unused
+ * @return void*    Pointer to result data, required by function prototype, unused
+ */
+static void * KeyboardThread(void * _);
+
+/**
+ * @brief Function to draw on screen initial state of emulated gpio terminals
+ */
+void DrawStatus(void);
+
+/**
+ * @brief Function to refresh on screen current state of one emulated gpio terminal
+ *
+ * @param  gpio     Pointer to the structure with the gpio terminal descriptor
+ */
+void RefreshStatus(hal_gpio_bit_t gpio);
+
+/* === Public variable definitions ============================================================= */
+
+/**
+ * @addtogroup posixGpio GPIO Constants
+ * @brief Constant for gpio terminals on board
+ * @{
+ */
+const hal_gpio_bit_t GPIO_BIT(0, 0); /**< Constant to define Bit 0 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(0, 1); /**< Constant to define Bit 1 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(0, 2); /**< Constant to define Bit 2 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(0, 3); /**< Constant to define Bit 3 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(0, 4); /**< Constant to define Bit 4 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(0, 5); /**< Constant to define Bit 5 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(0, 6); /**< Constant to define Bit 6 on GPIO 0 */
+const hal_gpio_bit_t GPIO_BIT(0, 7); /**< Constant to define Bit 7 on GPIO 0 */
+
+const hal_gpio_bit_t GPIO_BIT(1, 0); /**< Constant to define Bit 0 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 1); /**< Constant to define Bit 1 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 2); /**< Constant to define Bit 2 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 3); /**< Constant to define Bit 3 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 4); /**< Constant to define Bit 4 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 5); /**< Constant to define Bit 5 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 6); /**< Constant to define Bit 6 on GPIO 1 */
+const hal_gpio_bit_t GPIO_BIT(1, 7); /**< Constant to define Bit 7 on GPIO 1 */
+
+const hal_gpio_bit_t GPIO_BIT(2, 0); /**< Constant to define Bit 0 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(2, 1); /**< Constant to define Bit 1 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(2, 2); /**< Constant to define Bit 2 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(2, 3); /**< Constant to define Bit 3 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(2, 4); /**< Constant to define Bit 4 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(2, 5); /**< Constant to define Bit 5 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(2, 6); /**< Constant to define Bit 6 on GPIO 2 */
+const hal_gpio_bit_t GPIO_BIT(2, 7); /**< Constant to define Bit 7 on GPIO 2 */
+
+const hal_gpio_bit_t GPIO_BIT(3, 0); /**< Constant to define Bit 0 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(3, 1); /**< Constant to define Bit 1 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(3, 2); /**< Constant to define Bit 2 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(3, 3); /**< Constant to define Bit 3 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(3, 4); /**< Constant to define Bit 4 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(3, 5); /**< Constant to define Bit 5 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(3, 6); /**< Constant to define Bit 6 on GPIO 3 */
+const hal_gpio_bit_t GPIO_BIT(3, 7); /**< Constant to define Bit 7 on GPIO 3 */
+/** @} End of group posixGpio */
+
+/* === Private variable definitions ============================================================ */
+
+/* === Private function implementation ========================================================= */
+
+static void * KeyboardThread(void * _) {
+    struct termios ttystate;
+    struct hal_gpio_bit_s gpio = {.gpio = 0, .bit = 0};
+    char key;
+
+    tcgetattr(STDIN_FILENO, &ttystate);
+    ttystate.c_lflag &= (~ICANON & ~ECHO);
+    ttystate.c_cc[VMIN] = 1;
+    tcsetattr(STDIN_FILENO, TCSANOW, &ttystate);
+
+    while (true) {
+        key = getchar();
+        if ((key >= '1') && (key <= '8')) {
+            gpio.gpio = 0;
+            gpio.bit = key - '1';
+            GpioBitToogle(&gpio);
+        }
+    }
+    return 0;
+}
+
+void DrawStatus(void) {
+    static const char DRAW_INIT[] = "\033[2J\033[1;1H";
+    static const char DRAW_BIT[] = "%d=\033[1;31m%d\033[0m";
+    static const char DRAW_END[] = "\033[5A\n";
+
+    int gpio, bit;
+
+    printf(DRAW_INIT);
+    for (gpio = 0; gpio < 4; gpio++) {
+        printf("GPIO %d: ", gpio);
+        for (bit = 7; bit >= 0; bit--) {
+            printf(DRAW_BIT, bit, (gpio_emulation[gpio] >> (bit)) & 0x01);
+            if (bit > 0) {
+                printf(", ");
+            }
+        }
+        printf("\n");
+    }
+    printf(DRAW_END);
+}
+
+void RefreshStatus(hal_gpio_bit_t gpio) {
+    static const char DRAW_BIT[] = "\033[%d;%dH\033[1;%dm%d\033[0m";
+
+    uint8_t value = (gpio_emulation[gpio->gpio] >> (gpio->bit)) & 0x01;
+
+    printf(DRAW_BIT, gpio->gpio + 1, 46 - 5 * gpio->bit, value ? 32 : 31, value);
+    fflush(stdout);
+}
+
+/* === Public function implementation ========================================================== */
+
+void GpioSetDirection(hal_gpio_bit_t gpio, bool output) {
+    static bool initied_status = false;
+    static pthread_t thread;
+
+    if (!initied_status) {
+        initied_status = true;
+        DrawStatus();
+        pthread_create(&thread, NULL, KeyboardThread, NULL);
+    }
+    if (!output) {
+        GpioBitSet(gpio);
+    }
+}
+
+bool GpioGetState(hal_gpio_bit_t gpio) {
+    bool result = false;
+    if (gpio) {
+        result = (gpio_emulation[gpio->gpio] & (1 << gpio->bit)) != 0;
+    }
+    return result;
+}
+
+void GpioSetState(hal_gpio_bit_t gpio, bool state) {
+    if (state) {
+        GpioBitSet(gpio);
+    } else {
+        GpioBitClear(gpio);
+    }
+}
+
+void GpioBitSet(hal_gpio_bit_t gpio) {
+    if (gpio) {
+        gpio_emulation[gpio->gpio] |= (1 << gpio->bit);
+        RefreshStatus(gpio);
+    }
+}
+
+void GpioBitClear(hal_gpio_bit_t gpio) {
+    if (gpio) {
+        gpio_emulation[gpio->gpio] &= ~(1 << gpio->bit);
+        RefreshStatus(gpio);
+    }
+}
+
+void GpioBitToogle(hal_gpio_bit_t gpio) {
+    if (gpio) {
+        gpio_emulation[gpio->gpio] ^= (1 << gpio->bit);
+        RefreshStatus(gpio);
+    }
+}
+
+/* === End of documentation ==================================================================== */
+
+/** @} End of module definition for doxygen
+ ** @endcond */

--- a/module/hal/soc/posix/src/soc_pin.c
+++ b/module/hal/soc/posix/src/soc_pin.c
@@ -23,47 +23,45 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 SPDX-License-Identifier: MIT
 *************************************************************************************************/
 
-#ifndef HAL_H
-#define HAL_H
-
 /** @file
- ** @brief Harware abstraction layer declarations
+ ** @brief Chip pins on posix implementation
  **
- ** @addtogroup hal HAL
- ** @brief Hardware abstraction layer
+ ** @addtogroup posix Posix
+ ** @ingroup hal
+ ** @brief Posix SOC Hardware abstraction layer
+ ** @cond INTERNAL
  ** @{ */
 
-/* === Headers files inclusions ================================================================ */
+/* === Headers files inclusions =============================================================== */
 
-#include "hal_pin.h"
-#include "hal_sci.h"
-#include "hal_gpio.h"
-#include "hal_tick.h"
 #include "soc_pin.h"
-#include "soc_sci.h"
-#include "soc_gpio.h"
-#include "soc_tick.h"
 
-/* === Cabecera C++ ============================================================================ */
+/* === Macros definitions ====================================================================== */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+/* === Private data type declarations ========================================================== */
 
-/* === Public macros definitions =============================================================== */
+/* === Private variable declarations =========================================================== */
 
-/* === Public data type declarations =========================================================== */
+/* === Private function declarations =========================================================== */
 
-/* === Public variable declarations ============================================================ */
+/* === Public variable definitions ============================================================= */
 
-/* === Public function declarations ============================================================ */
+/* === Private variable definitions ============================================================ */
+
+/* === Private function implementation ========================================================= */
+
+/* === Public function implementation ========================================================== */
+
+void ChipPinSetFunction(hal_chip_pin_t pin, uint8_t function, bool pullup, bool puldown) {
+}
+
+void ChipPinSetPullUp(hal_chip_pin_t pin, bool enable) {
+}
+
+void ChipPinSetPullDown(hal_chip_pin_t pin, bool enable) {
+}
 
 /* === End of documentation ==================================================================== */
 
-#ifdef __cplusplus
-}
-#endif
-
-/** @} End of module definition for doxygen */
-
-#endif /* HAL_H */
+/** @} End of module definition for doxygen
+ ** @endcond */

--- a/module/hal/soc/posix/src/soc_sci.c
+++ b/module/hal/soc/posix/src/soc_sci.c
@@ -1,0 +1,73 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+/** @file
+ ** @brief Serial ports on posix implementation
+ **
+ ** @addtogroup posix Posix
+ ** @ingroup hal
+ ** @brief Posix SOC Hardware abstraction layer
+ ** @cond INTERNAL
+ ** @{ */
+
+/* === Headers files inclusions =============================================================== */
+
+#include "soc_sci.h"
+
+/* === Macros definitions ====================================================================== */
+
+/* === Private data type declarations ========================================================== */
+
+/* === Private variable declarations =========================================================== */
+
+/* === Private function declarations =========================================================== */
+
+/* === Public variable definitions ============================================================= */
+
+/* === Private variable definitions ============================================================ */
+
+/* === Private function implementation ========================================================= */
+
+/* === Public function implementation ========================================================== */
+
+void SciSetConfig(hal_sci_t sci, hal_sci_line_t line, hal_sci_pins_t pins) {
+}
+
+uint16_t SciSendData(hal_sci_t sci, void const * const data, uint16_t size) {
+}
+
+uint16_t SciReceiveData(hal_sci_t sci, void * data, uint16_t size) {
+}
+
+void SciReadStatus(hal_sci_t sci, sci_status_t result, bool clear_status) {
+}
+
+void SciSetEventHandler(hal_sci_t sci, hal_sci_event_t handler, void * data) {
+}
+
+/* === End of documentation ==================================================================== */
+
+/** @} End of module definition for doxygen
+ ** @endcond */

--- a/module/hal/soc/posix/src/soc_tick.c
+++ b/module/hal/soc/posix/src/soc_tick.c
@@ -1,0 +1,106 @@
+/************************************************************************************************
+Copyright (c) 2022-2023, Laboratorio de Microprocesadores
+Facultad de Ciencias Exactas y Tecnología, Universidad Nacional de Tucumán
+https://www.microprocesadores.unt.edu.ar/
+
+Copyright (c) 2022-2023, Esteban Volentini <evolentini@herrera.unt.edu.ar>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SPDX-License-Identifier: MIT
+*************************************************************************************************/
+
+/** @file
+ ** @brief System timer on posix implementation
+ **
+ ** @addtogroup posix Posix
+ ** @ingroup hal
+ ** @brief Posix SOC Hardware abstraction layer
+ ** @cond INTERNAL
+ ** @{ */
+
+/* === Headers files inclusions =============================================================== */
+
+#include "soc_tick.h"
+#include <pthread.h>
+#include <unistd.h>
+#include <stdio.h>
+
+/* === Macros definitions ====================================================================== */
+
+/* === Private data type declarations ========================================================== */
+
+/**
+ * @brief Pointer to the structure with the system timer descriptor
+ */
+typedef struct hal_tick_s {
+    pthread_t thread;         /**< Pointer to thread used to simulate timers events */
+    hal_tick_event_t handler; /**< Function to call on the system timer events */
+    void * object;            /**< Pointer to user data sended as parameter in handler calls */
+    uint32_t period;          /**< Period, in microseconds, between each system timer event */
+} * hal_tick_t;
+
+/* === Private variable declarations =========================================================== */
+
+/* === Private function declarations =========================================================== */
+
+/**
+ * @brief Function to implement a main loop of a thread send timer events
+ *
+ * @param _         Pointer to initial data, required by function prototype, unused
+ * @return void*    Pointer to result data, required by function prototype, unused
+ */
+static void * TimerThread(void * _);
+
+/* === Public variable definitions ============================================================= */
+
+/* === Private variable definitions ============================================================ */
+
+/**
+ * @brief Variable with the instance of system timer descriptor
+ */
+static struct hal_tick_s instance[1] = {0};
+
+/* === Private function implementation ========================================================= */
+
+static void * TimerThread(void * _) {
+    while (true) {
+        usleep(instance->period);
+        if (instance->handler) {
+            instance->handler(instance->object);
+        }
+    }
+    return 0;
+}
+
+/* === Public function implementation ========================================================== */
+
+void TickStart(hal_tick_event_t handler, void * object, uint32_t period) {
+    instance->handler = handler;
+    instance->object = object;
+    instance->period = period;
+    pthread_create(&instance->thread, NULL, TimerThread, NULL);
+}
+
+void SysTick_Handler(void) {
+    if (instance->handler) {
+        instance->handler(instance->object);
+    }
+}
+/* === End of documentation ==================================================================== */
+
+/** @} End of module definition for doxygen
+ ** @endcond */


### PR DESCRIPTION
Added a low-level abstraction layer that allows:
- Configure the multiplexing and the pullup and pulldown resistors of the chip terminals
- Configure and operate the digital input/output ports
- Configure and operate the serial communication ports through polling or interruptions
- Configure a service of periodic interruptions to generate a time base

An example of use was also added for the supported SOCs: 
- LPC4337: used by EDU-CIAA-NXP
- Posix:  hardware emulation over compatible posix compliant operating systems