### PR TITLE
Add `make config_vscode` target which creates `.vscode/c_cpp_properties.json`

### DIFF
--- a/module/base/makefile
+++ b/module/base/makefile
@@ -345,3 +345,38 @@ info:
 	@echo Objetos: $(PROJECT_OBJ)
 	@echo -------------------------------------------------------------------------------
 	@echo Definciones: $(DEFINES)
+
+##################################################################################################
+#
+COMMA := ,
+EMPTY :=
+SPACE := $(EMPTY) $(EMPTY)
+TAB := $(EMPTY)	$(EMPTY)
+json_list = $(subst $(SPACE),$(COMMA)$(SPACE),$(strip $(foreach w,$1,"$w")))
+
+MY_INCLUDES = $(strip $(foreach p,$(PROJECT_INC),$(subst $(abspath $(PROJECT_DIR)),$(PROJECT_DIR),$(call full_path,$(p)))))
+
+define vscode_c_config
+{
+	"configurations": [
+		{
+			"name": "MUJU",
+			"includePath": [$(call json_list,$(MY_INCLUDES))],
+			"defines": [$(call json_list,$(DEFINES))],
+			"cStandard": "c99",
+			"intelliSenseMode": "$${default}",
+			"compilerPath":"$(subst \,\\,$(shell $(CC) -v 2>&1 | awk '/COLLECT_GCC=/ {sub(/[^=]+=/,"");print}'))"
+		}
+	],
+	"version": 4
+}
+endef
+
+VSCODE_DIR=$(PROJECT_DIR)/.vscode
+VSCODE_CFG=$(VSCODE_DIR)/c_cpp_properties.json
+
+config_vscode: |$(VSCODE_DIR)
+	@echo "Creating or replacing $(VSCODE_CFG) $(file > $(VSCODE_CFG),$(subst $(TAB),$(SPACE)$(SPACE),$(vscode_c_config)))"
+
+$(VSCODE_DIR):
+	$(QUIET) mkdir -p $(VSCODE_DIR)

--- a/module/base/makefile
+++ b/module/base/makefile
@@ -348,26 +348,34 @@ info:
 
 ##################################################################################################
 #
+define NEWLINE
+
+
+endef
 COMMA := ,
 EMPTY :=
 SPACE := $(EMPTY) $(EMPTY)
-TAB := $(EMPTY)	$(EMPTY)
-json_list = $(subst $(SPACE),$(COMMA)$(SPACE),$(strip $(foreach w,$1,"$w")))
+TAB := $(SPACE)$(SPACE)$(SPACE)$(SPACE)
+INDENT := $(COMMA)\n$(TAB)$(TAB)$(TAB)$(TAB)
 
-MY_INCLUDES = $(strip $(foreach p,$(PROJECT_INC),$(subst $(abspath $(PROJECT_DIR)),$(PROJECT_DIR),$(call full_path,$(p)))))
+define json_list
+$(subst $(SPACE),$(INDENT),$(strip $(foreach w,$1,"$w")))
+endef
+
+VSCODE_INCLUDES = $(strip $(foreach p,$(PROJECT_INC),$(subst $(abspath $(PROJECT_DIR)),$(PROJECT_DIR),$(call full_path,$(p)))))
 
 define vscode_c_config
 {
-	"configurations": [
-		{
-			"name": "MUJU",
-			"includePath": [$(call json_list,$(MY_INCLUDES))],
-			"defines": [$(call json_list,$(DEFINES))],
-			"cStandard": "c99",
-			"intelliSenseMode": "$${default}",
-			"compilerPath":"$(subst \,\\,$(shell $(CC) -v 2>&1 | awk '/COLLECT_GCC=/ {sub(/[^=]+=/,"");print}'))"
-		}
-	],
+    "configurations": [
+        {
+            "name": "MUJU",
+            "includePath": [$(call json_list,$(VSCODE_INCLUDES))],
+            "defines": [$(call json_list,$(DEFINES))],
+            "cStandard": "c99",
+            "intelliSenseMode": "$${default}",
+            "compilerPath":"$(subst \,\\,$(shell $(CC) -v 2>&1 | awk '/COLLECT_GCC=/ {sub(/[^=]+=/,"");print}'))"
+        }
+    ],
 	"version": 4
 }
 endef
@@ -375,8 +383,9 @@ endef
 VSCODE_DIR=$(PROJECT_DIR)/.vscode
 VSCODE_CFG=$(VSCODE_DIR)/c_cpp_properties.json
 
-config_vscode: |$(VSCODE_DIR)
-	@echo "Creating or replacing $(VSCODE_CFG) $(file > $(VSCODE_CFG),$(subst $(TAB),$(SPACE)$(SPACE),$(vscode_c_config)))"
+vscode: |$(VSCODE_DIR)
+	@echo "Creating or replacing $(VSCODE_CFG)"
+	@echo '$(subst $(NEWLINE),\n,${vscode_c_config})' > $(VSCODE_CFG)
 
 $(VSCODE_DIR):
-	$(QUIET) mkdir -p $(VSCODE_DIR)
+	-@mkdir -p $(VSCODE_DIR)


### PR DESCRIPTION
The new make `vscode` target creates or replaces `.vscode/c_cpp_properties.json` with a configuration suitable for intellisense to work. This configuration sets the include paths, defines, and c compiler path. The configuration also sets the C standard to C99.
This pull request replaces and includes #32