### PR TITLE
Made `make vscode` compatible with MSYS2 and added `make clangd`

### DIFF
--- a/module/base/makefile
+++ b/module/base/makefile
@@ -356,7 +356,7 @@ COMMA := ,
 EMPTY :=
 SPACE := $(EMPTY) $(EMPTY)
 TAB := $(SPACE)$(SPACE)$(SPACE)$(SPACE)
-INDENT := $(COMMA)\n$(TAB)$(TAB)$(TAB)$(TAB)
+INDENT := $(COMMA)$(NEWLINE)$(TAB)$(TAB)$(TAB)$(TAB)
 
 define json_list
 $(subst $(SPACE),$(INDENT),$(strip $(foreach w,$1,"$w")))
@@ -383,9 +383,18 @@ endef
 VSCODE_DIR=$(PROJECT_DIR)/.vscode
 VSCODE_CFG=$(VSCODE_DIR)/c_cpp_properties.json
 
+
 vscode: |$(VSCODE_DIR)
 	@echo "Creating or replacing $(VSCODE_CFG)"
-	@echo '$(subst $(NEWLINE),\n,${vscode_c_config})' > $(VSCODE_CFG)
+	@echo '$(subst $(NEWLINE),>>>>,$(subst ','\'',${vscode_c_config}))' | awk 'gsub(/>>>>/,"\n")' > $(VSCODE_CFG)
 
 $(VSCODE_DIR):
 	-@mkdir -p $(VSCODE_DIR)
+
+CLANGD_CONFIG_FILE = $(PROJECT_DIR)/compile_flags.txt
+
+CLANGD_CONFIG_CONTENT = $(patsubst %,-I%,$(VSCODE_INCLUDES)) $(patsubst %,-D%,$(DEFINES)) -Wall -Wextra -Wpedantic -std=c99
+
+clangd:
+	@echo "Creating or replacing $(CLANGD_CONFIG_FILE)"
+	@echo $(CLANGD_CONFIG_CONTENT) | tr ' ' '\n' >$(CLANGD_CONFIG_FILE)


### PR DESCRIPTION
The first version of `make vscode` relied on echo processing the `\n` escape sequence in single-quoted text. This happens in mac os and linux's default shell *sh* but not in MSYS2's default shell *bash* which requires a `-e` switch. This same switch is echoed unmodified by sh's version of `echo`, so it is not a viable solution.

As a workaround, newlines are replaced by `>>>>` (a sequence that shouldn't appear in text) and then filtering through awk reliably replaces the sequence by a newline before redirecting to create the configuration file.

To support users of the clangd LSP (for instance, vim users) a new target, `make clangd` was added. This target creates a `compile_flags.txt` file in the repository's root, with flags that setup clangd in a manner similar to vscode. This also requires newlines but here `tr` was used as a filter in place of `awk` because the input is a space-separated list and the only substitution necessary is space to newline