### PR TITLE
Closes #40. Fix openocd.cfg for lpc4337, issue pertaining m0 core not halting.

### DIFF
--- a/external/base/mcu/lpc4337-m4/openocd/openocd.cfg
+++ b/external/base/mcu/lpc4337-m4/openocd/openocd.cfg
@@ -28,12 +28,19 @@ target create $_CHIPNAME.m0 cortex_m -dap $_CHIPNAME.m0.dap
 set _WORKAREASIZE 0x8000
 $_CHIPNAME.m4 configure -work-area-phys 0x10000000 -work-area-size $_WORKAREASIZE
 
+$_CHIPNAME.m0 configure -event reset-deassert-post {
+    echo "Putting core m0 to run so that it can halt, otherwise reset init fails..."
+    mww phys 0x40053104 0x00000000
+}
+
 set _FLASHNAME $_CHIPNAME.flash
 flash bank $_FLASHNAME lpc2000 0x1a000000 0x80000 0 0 $_CHIPNAME.m4 lpc4300 96000 calc_checksum
 
 reset_config none
 
-cortex_m reset_config vectreset
+$_CHIPNAME.m4 cortex_m reset_config vectreset
+
+$_CHIPNAME.m0 cortex_m reset_config sysresetreq
 
 targets $_CHIPNAME.m4
 


### PR DESCRIPTION
OpenOCD's reset halt resets and halts *all cores*. The m0 core in lpc4337 is held reset until deasserted by software by writing a zero in bit 24 of RESET_CTRL1, therefore it cannot halt and causes a timeout.

This breaks OpenOCD's `program` command which, as part of the programming sequence, uses `reset init` that expects the m0 core to halt. Furthermore the m0 core doesn't support the vectreset method and must be reset by sysresetreq.

To fix the error, lpc4337's openocd.cfg was modified in three ways:

- Added an event handler to lpc4337.m0 that writes 0 to RESET_CTRL1, thus deasserting the m0 core's reset so it can be halted
- Applied the vectreset reset_config only to lpc4337.m4
- Applied the sysresetreq reset_config to lpc4337.m0

The fix was tested  with an edu-ciaa-nxp board